### PR TITLE
Remove cancel-in-progress on sonar jobs.

### DIFF
--- a/.github/workflows/danger_checks.yml
+++ b/.github/workflows/danger_checks.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   danger:
     env:

--- a/.github/workflows/sync_main.yml
+++ b/.github/workflows/sync_main.yml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: macos-14


### PR DESCRIPTION
This prevents sync job from running so we remove it to give that task also the chance to run