### PR TITLE
Update dependencies and plugins

### DIFF
--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -137,7 +137,7 @@ dependencies {
     implementation(libs.koin.android)
     implementation(projects.core.utils)
     implementation(libs.androidx.core)
-    implementation("org.jetbrains.androidx.core:core-uri:1.0.0-alpha01")
+    implementation(libs.androidx.core.uri)
     testImplementation(libs.koin.android)
     testImplementation(libs.koin.test)
     implementation(libs.kotlinx.serialization.json)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     alias(libs.plugins.sonar).apply(false)
     alias(libs.plugins.android.test).apply(false)
     alias(libs.plugins.kotlin.parcelize).apply(false)
-    alias(libs.plugins.kotlin.dokka)
     alias(libs.plugins.ktlint)
     id("com.superdiary.ktlint")
     id("com.superdiary.githooks")

--- a/core/auth/build.gradle.kts
+++ b/core/auth/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 
                 implementation(dependencies.platform(libs.supabase.bom))
                 implementation(libs.supabase.posgrest)
-                implementation("org.jetbrains.androidx.core:core-uri:1.0.0-alpha01")
+                implementation(libs.androidx.core.uri)
                 api(libs.supabase.auth)
                 implementation(libs.supabase.realtime)
                 implementation(libs.supabase.compose.auth)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs") {
-            from("io.github.rafsanjani:versions:2024.12.25")
+            from("io.github.rafsanjani:versions:2024.12.26")
             version("openaiKotlin", "4.0.0-SNAPSHOT")
             version("kotlinSerialization", "1.8.0-RC")
         }

--- a/shared-ui/build.gradle.kts
+++ b/shared-ui/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
                 implementation(libs.coil3.network.ktor)
                 implementation(libs.coil3.multiplatform)
                 implementation(libs.ktor.client.core)
-                implementation("io.insert-koin:koin-compose-viewmodel:4.0.1")
+                implementation(libs.koin.compose.viewmodel)
                 api(projects.core.auth)
                 api(projects.core.analytics)
                 api(projects.core.location)


### PR DESCRIPTION
Update dependencies and plugins

- Update version catalog from `2024.12.25` to `2024.12.26`.
- Remove `kotlin.dokka` plugin.
- Update `koin-compose-viewmodel` dependency to `libs.koin.compose.viewmodel`.
- Update `org.jetbrains.androidx.core:core-uri` dependency to `libs.androidx.core.uri`.
```