### PR TITLE
Fix context provider crash

### DIFF
--- a/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/DiaryApp.kt
+++ b/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/DiaryApp.kt
@@ -10,11 +10,10 @@ import com.foreverrafs.superdiary.core.logging.SentryLogger
 import com.foreverrafs.superdiary.ui.di.compositeModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 
 class DiaryApp : Application(), KoinComponent {
-    private val androidContextProvider: AndroidContextProvider by inject()
+    private val androidContextProvider = AndroidContextProvider.getInstance()
     override fun onCreate() {
         super.onCreate()
         initializeKoin()
@@ -22,36 +21,30 @@ class DiaryApp : Application(), KoinComponent {
     }
 
     private fun registerAndroidContextProviderCallbacks() {
-        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-                androidContextProvider.setContext(activity)
-            }
+        registerActivityLifecycleCallbacks(
+            object : ActivityLifecycleCallbacks {
+                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) =
+                    Unit
 
-            override fun onActivityStarted(activity: Activity) {
-                androidContextProvider.setContext(activity)
-            }
+                override fun onActivityStarted(activity: Activity) = Unit
 
-            // Sometimes activities will cycle between paused and resumed states
-            override fun onActivityResumed(activity: Activity) {
-                androidContextProvider.setContext(activity)
-            }
+                // Sometimes activities will cycle between paused and resumed states
+                override fun onActivityResumed(activity: Activity) {
+                    androidContextProvider.setContext(activity)
+                }
 
-            override fun onActivityPaused(activity: Activity) {
-                androidContextProvider.clearContext()
-            }
+                override fun onActivityPaused(activity: Activity) {
+                    androidContextProvider.clearContext()
+                }
 
-            // Cleared in onPaused but being extra cautious
-            override fun onActivityStopped(activity: Activity) {
-                androidContextProvider.clearContext()
-            }
+                override fun onActivityStopped(activity: Activity) = Unit
 
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) =
+                    Unit
 
-            // Cleared in onPaused but being extra cautious
-            override fun onActivityDestroyed(activity: Activity) {
-                androidContextProvider.clearContext()
-            }
-        })
+                override fun onActivityDestroyed(activity: Activity) = Unit
+            },
+        )
     }
 
     private fun initializeKoin() {

--- a/core/auth/src/androidMain/kotlin/com/foreverrafs/auth/AndroidContextProvider.kt
+++ b/core/auth/src/androidMain/kotlin/com/foreverrafs/auth/AndroidContextProvider.kt
@@ -1,5 +1,6 @@
 package com.foreverrafs.auth
 
+import android.annotation.SuppressLint
 import android.content.Context
 
 /**
@@ -11,9 +12,15 @@ import android.content.Context
  * This should only be used from the Application class where it can be
  * cleared in a structured manner
  */
-class AndroidContextProvider {
+class AndroidContextProvider private constructor() {
     private var context: Context? = null
     fun getContext(): Context? = context
+
+    companion object {
+        @SuppressLint("StaticFieldLeak")
+        private val instance = AndroidContextProvider()
+        fun getInstance(): AndroidContextProvider = instance
+    }
 
     fun setContext(context: Context) {
         this.context = context

--- a/core/auth/src/androidMain/kotlin/com/foreverrafs/auth/di/AuthModule.android.kt
+++ b/core/auth/src/androidMain/kotlin/com/foreverrafs/auth/di/AuthModule.android.kt
@@ -8,11 +8,10 @@ import com.foreverrafs.auth.BiometricAuth
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 internal actual fun platformAuthModule(): Module = module {
-    singleOf(::AndroidContextProvider)
+    single<AndroidContextProvider> { AndroidContextProvider.getInstance() }
     factoryOf(::AndroidAuth) { bind<AuthApi>() }
     factoryOf(::AndroidBiometricAuth) { bind<BiometricAuth>() }
 }


### PR DESCRIPTION
This was because of a race condition between onDestroy and onStart causing the context to be removed by the stopping activity immediately after it has been set by the incoming activity