### PR TITLE
Make preference annotation typesafe

### DIFF
--- a/preferences/annotation/src/commonMain/kotlin/com/foreverrafs/preferences/Preference.kt
+++ b/preferences/annotation/src/commonMain/kotlin/com/foreverrafs/preferences/Preference.kt
@@ -1,9 +1,7 @@
 package com.foreverrafs.preferences
 
+@Suppress("unused")
 @Target(AnnotationTarget.CLASS)
 annotation class Preference(
-    val name: String,
+    val generatedClassName: String,
 )
-
-@Target(AnnotationTarget.PROPERTY)
-annotation class PreferenceKey(val defaultValue: String)

--- a/preferences/annotation/src/commonMain/kotlin/com/foreverrafs/preferences/PreferenceKey.kt
+++ b/preferences/annotation/src/commonMain/kotlin/com/foreverrafs/preferences/PreferenceKey.kt
@@ -1,0 +1,20 @@
+package com.foreverrafs.preferences
+
+@Suppress("unused")
+@Target(AnnotationTarget.PROPERTY)
+annotation class PreferenceKey {
+    @Target(AnnotationTarget.PROPERTY)
+    annotation class String(val default: kotlin.String)
+
+    @Target(AnnotationTarget.PROPERTY)
+    annotation class Int(val default: kotlin.Int)
+
+    @Target(AnnotationTarget.PROPERTY)
+    annotation class Boolean(val default: kotlin.Boolean)
+
+    @Target(AnnotationTarget.PROPERTY)
+    annotation class Float(val default: kotlin.Float)
+
+    @Target(AnnotationTarget.PROPERTY)
+    annotation class Double(val default: kotlin.Double)
+}

--- a/preferences/processor/src/commonMain/kotlin/com/foreverrafs/preferences/codegen/Extensions.kt
+++ b/preferences/processor/src/commonMain/kotlin/com/foreverrafs/preferences/codegen/Extensions.kt
@@ -1,0 +1,44 @@
+package com.foreverrafs.preferences.codegen
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.toClassName
+
+fun Resolver.filterDataClassesWithAnnotation(annotation: String): Sequence<KSClassDeclaration> =
+    getSymbolsWithAnnotation(annotation)
+        .filterIsInstance<KSClassDeclaration>()
+        .filter {
+            Modifier.DATA in it.modifiers
+        }
+
+fun KSPropertyDeclaration.getValueAsString(): String {
+    fun illegalStateException(): Unit =
+        throw IllegalStateException("Property and annotation type mismatch for ${this.simpleName.asString()}. Please Ensure that the property type is the same as the @PreferenceKey type used")
+
+    val resolvedProperty = type.resolve().toClassName()
+
+    val firstAnnotatedValue = annotations
+        .firstOrNull()
+        ?.arguments
+        ?.firstOrNull()
+        ?.value
+        ?: throw IllegalStateException("The property ${simpleName.asString()} hasn't been annotated with @PreferenceKey. Please ensure all properties have been annotated")
+
+    val value = when (resolvedProperty) {
+        Boolean::class.asClassName() ->
+            firstAnnotatedValue as? Boolean
+                ?: illegalStateException()
+
+        Int::class.asClassName() -> firstAnnotatedValue as? Int ?: illegalStateException()
+        Float::class.asClassName() -> firstAnnotatedValue as? Float ?: illegalStateException()
+        Long::class.asClassName() -> firstAnnotatedValue as? Long ?: illegalStateException()
+        Double::class.asClassName() -> firstAnnotatedValue as? Double ?: illegalStateException()
+        String::class.asClassName() -> "\"${firstAnnotatedValue as? String ?: illegalStateException()}\""
+        else -> null
+    }
+
+    return value.toString()
+}

--- a/shared-data/src/commonMain/kotlin/com/foreverrafs/superdiary/utils/DiarySettings.kt
+++ b/shared-data/src/commonMain/kotlin/com/foreverrafs/superdiary/utils/DiarySettings.kt
@@ -5,25 +5,25 @@ import com.foreverrafs.preferences.PreferenceKey
 
 @Preference("DiaryPreference")
 data class DiarySettings(
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val isFirstLaunch: Boolean,
 
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val showWeeklySummary: Boolean,
 
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val showAtAGlance: Boolean,
 
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val showLatestEntries: Boolean,
 
-    @PreferenceKey(defaultValue = "false")
+    @PreferenceKey.Boolean(default = false)
     val isBiometricAuthEnabled: Boolean,
 
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val showLocationPermissionDialog: Boolean,
 
-    @PreferenceKey(defaultValue = "true")
+    @PreferenceKey.Boolean(default = true)
     val showBiometricAuthDialog: Boolean,
 ) {
     companion object {


### PR DESCRIPTION
Introduce type specific sub @PreferenceKey annotations which can be used for specific data types. The following types are currently supported. 
```
@PreferenceKey.String
@PreferenceKey.Boolean
@PreferenceKey.Int
@PreferenceKey.Float
```