### PR TITLE
Remove deeplink navigation in favor of regular navigation 

### DIFF
--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/navigation/Navigation.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/navigation/Navigation.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
 import com.foreverrafs.superdiary.design.style.animatedComposable
@@ -32,13 +31,7 @@ inline fun <reified T : Any> NavGraphBuilder.diaryListNavigation(
             )
         }
 
-        animatedComposable<DiaryListRoute.DetailScreen>(
-            deepLinks = listOf(
-                navDeepLink {
-                    uriPattern = DiaryListRoute.DetailScreen.DEEPLINK_URI_PATTERN
-                },
-            ),
-        ) { backstackEntry ->
+        animatedComposable<DiaryListRoute.DetailScreen> { backstackEntry ->
             val diaryId: String = backstackEntry.toRoute<DiaryListRoute.DetailScreen>().diaryId
 
             DetailScreen(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,6 @@ dependencyResolutionManagement {
         create("libs") {
             from("io.github.rafsanjani:versions:2025.07.20")
             version("richTextEditor", "1.0.0-rc12")
-            version("datastore", "1.2.0-alpha02")
             // Downgrading to 3.1.3 because 3.2.0 doesn't play well with R8
             version("ktor", "3.1.3")
             version("jetbrainsNavigation", "2.9.0-beta03")

--- a/shared-ui/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/App.kt
+++ b/shared-ui/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/App.kt
@@ -24,9 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.uri.UriUtils
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavDeepLinkRequest
 import androidx.navigation.NavType
-import androidx.navigation.NavUri
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
@@ -269,12 +267,7 @@ private fun SuperDiaryNavHost(
                     },
                     onDiaryClick = {
                         navController.navigate(
-                            request = NavDeepLinkRequest.Builder.fromUri(
-                                NavUri(
-                                    UriUtils.encode("${DiaryListRoute.DetailScreen.URI_PATH}/$it"),
-                                ),
-                            )
-                                .build(),
+                            DiaryListRoute.DetailScreen(it.toString()),
                         )
                     },
                 )


### PR DESCRIPTION
in favor of regular navigation This is made possible by the fact that the whole app is now a single giant navigation graph so all destinations has a link to one another