### PR TITLE
Implement JVM permission no-ops

### DIFF
--- a/core/permission/src/jvmMain/kotlin/com/foreverrafs/superdiary/core/permission/JvmPermissionsControllerWrapper.kt
+++ b/core/permission/src/jvmMain/kotlin/com/foreverrafs/superdiary/core/permission/JvmPermissionsControllerWrapper.kt
@@ -2,20 +2,18 @@ package com.foreverrafs.superdiary.core.permission
 
 class JvmPermissionsControllerWrapper : PermissionsControllerWrapper {
     override suspend fun providePermission(permission: Permission) {
-        // TODO: Request for permission on macos
+        // No runtime permissions on JVM; treat as granted.
     }
 
     override suspend fun isPermissionGranted(permission: Permission): Boolean {
-        // TODO: Check for permission state on macos
         return true
     }
 
     override suspend fun getPermissionState(permission: Permission): PermissionState {
-        // TODO: Check for permission state on macos
         return PermissionState.Granted
     }
 
     override fun openAppSettings() {
-        // TODO: Open app settings on macos
+        // No-op on JVM; app settings are managed by the OS.
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a concrete JVM implementation for permission handling so desktop builds behave deterministically instead of containing `TODO` placeholders.

### Description
- Update `core/permission/src/jvmMain/kotlin/com/foreverrafs/superdiary/core/permission/JvmPermissionsControllerWrapper.kt` to treat permissions as granted by default by making `providePermission` a no-op, `isPermissionGranted` return `true`, `getPermissionState` return `PermissionState.Granted`, and `openAppSettings` a no-op.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982a9453d2483229ed83c2048126097)