### PR TITLE
Move ProfileScreen back to outer NavDisplay, navigate from Dashboard tab

### DIFF
--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
-import com.foreverrafs.superdiary.design.style.LocalOuterNavAnimatedContentScope
+import com.foreverrafs.superdiary.design.style.LocalRootAnimatedContentScope
 import com.foreverrafs.superdiary.design.style.LocalSharedTransitionScope
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import org.jetbrains.compose.resources.painterResource
@@ -45,7 +45,7 @@ fun AppBar(
     title: String? = null,
 ) {
     val sharedTransitionScope = LocalSharedTransitionScope.current
-    val sharedAnimatedContentScope = LocalOuterNavAnimatedContentScope.current
+    val sharedAnimatedContentScope = LocalRootAnimatedContentScope.current
         ?: LocalNavAnimatedContentScope.current
 
     with(sharedTransitionScope) {

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import com.foreverrafs.superdiary.design.style.LocalOuterNavAnimatedContentScope
 import com.foreverrafs.superdiary.design.style.LocalSharedTransitionScope
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import org.jetbrains.compose.resources.painterResource
@@ -44,7 +45,8 @@ fun AppBar(
     title: String? = null,
 ) {
     val sharedTransitionScope = LocalSharedTransitionScope.current
-    val sharedAnimatedContentScope = LocalNavAnimatedContentScope.current
+    val sharedAnimatedContentScope = LocalOuterNavAnimatedContentScope.current
+        ?: LocalNavAnimatedContentScope.current
 
     with(sharedTransitionScope) {
         TopAppBar(

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/style/SuperdiaryTheme.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/style/SuperdiaryTheme.kt
@@ -2,6 +2,7 @@
 
 package com.foreverrafs.superdiary.design.style
 
+import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -156,4 +157,18 @@ fun montserratAlternativesFontFamily(): FontFamily = FontFamily(
 @OptIn(ExperimentalSharedTransitionApi::class)
 val LocalSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope> {
     error("SharedTransitionScope not present")
+}
+
+/**
+ * The outer [AnimatedContentScope] provided by the top-level [NavDisplay] (screen-level
+ * navigation). Tabs (rendered by an inner [NavDisplay]) shadow [LocalNavAnimatedContentScope]
+ * with their own tab-level scope, breaking shared element transitions that cross the
+ * tab → screen boundary (e.g. profile avatar → profile image).
+ *
+ * Set this in [BottomNavigationScreen] before the inner [NavDisplay] so each tab's
+ * [AppBar] can use it for its [sharedElement] registration.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalOuterNavAnimatedContentScope = staticCompositionLocalOf<AnimatedContentScope?> {
+    null
 }

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/style/SuperdiaryTheme.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/style/SuperdiaryTheme.kt
@@ -160,15 +160,13 @@ val LocalSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope>
 }
 
 /**
- * The outer [AnimatedContentScope] provided by the top-level [NavDisplay] (screen-level
- * navigation). Tabs (rendered by an inner [NavDisplay]) shadow [LocalNavAnimatedContentScope]
+ * The outer [AnimatedContentScope] provided by the top-level [androidx.navigation3.ui.NavDisplay] (screen-level
+ * navigation). Tabs (rendered by an inner [androidx.navigation3.ui.NavDisplay]) shadow [LocalRootAnimatedContentScope]
  * with their own tab-level scope, breaking shared element transitions that cross the
  * tab → screen boundary (e.g. profile avatar → profile image).
  *
- * Set this in [BottomNavigationScreen] before the inner [NavDisplay] so each tab's
- * [AppBar] can use it for its [sharedElement] registration.
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
-val LocalOuterNavAnimatedContentScope = staticCompositionLocalOf<AnimatedContentScope?> {
+val LocalRootAnimatedContentScope = staticCompositionLocalOf<AnimatedContentScope?> {
     null
 }

--- a/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/navigation/BottomNavigationScreen.kt
+++ b/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/navigation/BottomNavigationScreen.kt
@@ -9,15 +9,18 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.navigation3.ui.NavDisplay
 import com.foreverrafs.auth.model.UserInfo
 import com.foreverrafs.superdiary.chat.presentation.screen.DiaryChatTab
 import com.foreverrafs.superdiary.dashboard.screen.DashboardTab
+import com.foreverrafs.superdiary.design.style.LocalOuterNavAnimatedContentScope
 import com.foreverrafs.superdiary.favorite.screen.FavoriteTab
 import com.foreverrafs.superdiary.list.presentation.list.DiaryListTab
 import com.foreverrafs.superdiary.ui.components.SuperDiaryBottomBar
@@ -36,7 +39,12 @@ fun BottomNavigationScreen(
     onDiaryClick: (diaryId: Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // This snackbar host state is used to show snackbars on the main screen
+    // Capture the outer NavDisplay's AnimatedContentScope before the inner
+    // NavDisplay shadows LocalNavAnimatedContentScope with the tab-level scope.
+    // The AppBar's shared element source needs this scope to match the destination
+    // in ProfileScreen.
+    val outerNavAnimatedContentScope = LocalNavAnimatedContentScope.current
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     val navigationState = rememberNavigationState(
@@ -105,10 +113,14 @@ fun BottomNavigationScreen(
                 }
             }
 
-            NavDisplay(
-                entries = navigationState.toEntries(entryProvider),
-                onBack = navigator::goBack,
-            )
+            CompositionLocalProvider(
+                LocalOuterNavAnimatedContentScope provides outerNavAnimatedContentScope,
+            ) {
+                NavDisplay(
+                    entries = navigationState.toEntries(entryProvider),
+                    onBack = navigator::goBack,
+                )
+            }
         }
     }
 }

--- a/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/navigation/BottomNavigationScreen.kt
+++ b/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/navigation/BottomNavigationScreen.kt
@@ -20,7 +20,7 @@ import androidx.navigation3.ui.NavDisplay
 import com.foreverrafs.auth.model.UserInfo
 import com.foreverrafs.superdiary.chat.presentation.screen.DiaryChatTab
 import com.foreverrafs.superdiary.dashboard.screen.DashboardTab
-import com.foreverrafs.superdiary.design.style.LocalOuterNavAnimatedContentScope
+import com.foreverrafs.superdiary.design.style.LocalRootAnimatedContentScope
 import com.foreverrafs.superdiary.favorite.screen.FavoriteTab
 import com.foreverrafs.superdiary.list.presentation.list.DiaryListTab
 import com.foreverrafs.superdiary.ui.components.SuperDiaryBottomBar
@@ -43,7 +43,7 @@ fun BottomNavigationScreen(
     // NavDisplay shadows LocalNavAnimatedContentScope with the tab-level scope.
     // The AppBar's shared element source needs this scope to match the destination
     // in ProfileScreen.
-    val outerNavAnimatedContentScope = LocalNavAnimatedContentScope.current
+    val rootAnimatedContentScope = LocalNavAnimatedContentScope.current
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -114,7 +114,7 @@ fun BottomNavigationScreen(
             }
 
             CompositionLocalProvider(
-                LocalOuterNavAnimatedContentScope provides outerNavAnimatedContentScope,
+                LocalRootAnimatedContentScope provides rootAnimatedContentScope,
             ) {
                 NavDisplay(
                     entries = navigationState.toEntries(entryProvider),


### PR DESCRIPTION
Profile avatar shared element transition broke when the AppBar moved into individual tabs - the source and destination lived in different NavDisplay scopes. Dashboard tab is now the single entry point for the profile screen. DashboardTab owns internal Dashboard-Profile navigation via state toggle. Removed avatar from other tabs and DiaryDetailScreen.