### PR TITLE
feat: clear saved chats from chat screen

### DIFF
--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
@@ -43,6 +44,7 @@ fun AppBar(
     onProfileClick: () -> Unit = {},
     avatarUrl: String? = null,
     title: String? = null,
+    actions: @Composable RowScope.() -> Unit = {},
 ) {
     val sharedTransitionScope = LocalSharedTransitionScope.current
     val sharedAnimatedContentScope = LocalRootAnimatedContentScope.current
@@ -73,6 +75,7 @@ fun AppBar(
                 containerColor = MaterialTheme.colorScheme.background,
             ),
             actions = {
+                actions()
                 Image(
                     modifier = Modifier
                         .sharedElement(

--- a/feature/diary-chat/src/commonMain/composeResources/values/strings.xml
+++ b/feature/diary-chat/src/commonMain/composeResources/values/strings.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="content_description_button_send">Send</string>
+    <string name="content_description_clear_chat">Clear chat</string>
 </resources>

--- a/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/data/DiaryChatRepositoryImpl.kt
+++ b/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/data/DiaryChatRepositoryImpl.kt
@@ -29,6 +29,10 @@ class DiaryChatRepositoryImpl(
         database.saveChatMessage(message.toDatabase())
     }
 
+    override suspend fun clearChatMessages() {
+        database.clearChatMessages()
+    }
+
     override fun getChatMessages(): Flow<List<DiaryChatMessage>> = database.getChatMessages().map { chatMessages ->
         chatMessages.map { it.toDiaryChatMessage() }
     }

--- a/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/domain/repository/DiaryChatRepository.kt
+++ b/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/domain/repository/DiaryChatRepository.kt
@@ -12,4 +12,6 @@ interface DiaryChatRepository {
     suspend fun queryDiaries(messages: List<DiaryChatMessage>): String?
 
     suspend fun saveChatMessage(message: DiaryChatMessage)
+
+    suspend fun clearChatMessages()
 }

--- a/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/DiaryChatViewModel.kt
+++ b/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/DiaryChatViewModel.kt
@@ -159,6 +159,20 @@ class DiaryChatViewModel(
         ) ?: it
     }
 
+    fun clearChatMessages() = viewModelScope.launch(dispatchers.io) {
+        repository.clearChatMessages()
+
+        _viewState.update {
+            DiaryChatViewState.Initialized(
+                messages = listOf(
+                    DiaryChatMessage.System(
+                        content = DiaryAI.QUERY_PROMPT,
+                    ),
+                ),
+            )
+        }
+    }
+
     private fun updateInitializedState(
         func: (current: DiaryChatViewState.Initialized) -> DiaryChatViewState.Initialized,
     ) {

--- a/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/screen/DiaryChatScreenContent.kt
+++ b/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/screen/DiaryChatScreenContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -37,6 +38,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -85,8 +87,10 @@ fun DiaryChatScreenContent(
     onProfileClick: () -> Unit = {},
     onQueryDiaries: (query: String) -> Unit = {},
     onDismissError: () -> Unit = {},
+    onClearChat: () -> Unit = {},
 ) {
     val currentOnDismissError by rememberUpdatedState(onDismissError)
+    var showClearConfirmation by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -94,6 +98,15 @@ fun DiaryChatScreenContent(
                 avatarUrl = avatarUrl,
                 onProfileClick = onProfileClick,
                 title = "Spartan AI",
+                actions = {
+                    IconButton(onClick = { showClearConfirmation = true }) {
+                        Text(
+                            text = "✕",
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                },
             )
         },
         modifier = modifier.fillMaxSize(),
@@ -248,6 +261,29 @@ fun DiaryChatScreenContent(
                     }
                 }
             }
+        }
+
+        if (showClearConfirmation) {
+            AlertDialog(
+                onDismissRequest = { showClearConfirmation = false },
+                title = { Text("Clear chat?") },
+                text = { Text("This will delete all saved chat messages. This action cannot be undone.") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showClearConfirmation = false
+                            onClearChat()
+                        },
+                    ) {
+                        Text("Clear")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearConfirmation = false }) {
+                        Text("Cancel")
+                    }
+                },
+            )
         }
     }
 }

--- a/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/screen/DiaryChatTab.kt
+++ b/feature/diary-chat/src/commonMain/kotlin/com/foreverrafs/superdiary/chat/presentation/screen/DiaryChatTab.kt
@@ -23,5 +23,6 @@ fun DiaryChatTab(
         onQueryDiaries = viewModel::queryDiaries,
         onDismissError = viewModel::dismissError,
         onProfileClick = onProfileClick,
+        onClearChat = viewModel::clearChatMessages,
     )
 }

--- a/feature/diary-chat/src/commonTest/kotlin/com/foreverrafs/superdiary/chat/DiaryChatViewModelTest.kt
+++ b/feature/diary-chat/src/commonTest/kotlin/com/foreverrafs/superdiary/chat/DiaryChatViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.foreverrafs.superdiary.chat.domain.repository.DiaryChatRepository
 import com.foreverrafs.superdiary.chat.presentation.DiaryChatViewModel
 import com.foreverrafs.superdiary.chat.presentation.DiaryChatViewState
@@ -52,6 +53,7 @@ class DiaryChatViewModelTest {
         )
         every { diaryChatRepository.getChatMessages() }.returns(flowOf(emptyList()))
         everySuspend { diaryChatRepository.saveChatMessage(any()) }.returns(Unit)
+        everySuspend { diaryChatRepository.clearChatMessages() }.returns(Unit)
 
         diaryChatViewModel = DiaryChatViewModel(
             logger = AggregateLogger(emptyList()),
@@ -110,6 +112,38 @@ class DiaryChatViewModelTest {
             val state =
                 awaitUntil { it is DiaryChatViewState.Initialized && it.errorText != null } as DiaryChatViewState.Initialized
             assertThat(state.errorText).isNotNull()
+        }
+    }
+
+    @Test
+    fun `Clearing chat resets messages to system message only`() = runTest {
+        diaryChatViewModel.viewState.test {
+            // Wait for initialization
+            val initState = awaitUntil {
+                it is DiaryChatViewState.Initialized && it.messages.isNotEmpty()
+            } as DiaryChatViewState.Initialized
+            assertThat(initState.messages.size).isEqualTo(2)
+
+            // Add a user message so we have something to clear
+            diaryChatViewModel.queryDiaries("hello")
+            everySuspend { diaryChatRepository.queryDiaries(any()) }.returns("response")
+
+            awaitUntil {
+                it is DiaryChatViewState.Initialized && it.messages.size > 2
+            }
+
+            // Now clear
+            diaryChatViewModel.clearChatMessages()
+
+            val clearedState = awaitUntil {
+                it is DiaryChatViewState.Initialized && it.messages.size == 1
+            } as DiaryChatViewState.Initialized
+
+            assertThat(clearedState.messages.size).isEqualTo(1)
+            assertThat(clearedState.isResponding).isEqualTo(false)
+            assertThat(clearedState.errorText).isNull()
+
+            cancelAndIgnoreRemainingEvents()
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a "Clear chat" button to the Diary AI chat screen, allowing users to delete all saved chat messages.

## Changes

- **AppBar** — Added optional `actions` parameter so callers can add action buttons alongside the profile avatar
- **DiaryChatRepository** — Added `clearChatMessages()` suspend function
- **DiaryChatRepositoryImpl** — Implements by delegating to `Database.clearChatMessages()`
- **DiaryChatViewModel** — Added `clearChatMessages()` that clears DB messages and resets the view state to just the system prompt
- **DiaryChatScreenContent** — Added clear button (✕) in the AppBar with a confirmation dialog before clearing
- **DiaryChatTab** — Wired `onClearChat` callback to ViewModel
- **Strings** — Added `content_description_clear_chat` string resource
- **Tests** — Added test verifying that clearing chat resets messages to a single system message

## Testing

- [x] Unit tests pass
- [x] Compilation successful

Closes #506