### PR TITLE
fix: request location permission before opening settings

### DIFF
--- a/core/permission/src/commonMain/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManager.kt
+++ b/core/permission/src/commonMain/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManager.kt
@@ -26,7 +26,10 @@ class LocationPermissionManager(
     }
 
     suspend fun provideLocationPermission() {
-        if (_permissionState.value == PermissionState.DeniedAlways) {
+        val currentState = permissionsController.getPermissionState(LocationPermission)
+        _permissionState.update { currentState }
+
+        if (currentState == PermissionState.DeniedAlways) {
             logger.i(TAG) {
                 "Location is permanently denied. Opening app settings"
             }

--- a/core/permission/src/commonMain/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManager.kt
+++ b/core/permission/src/commonMain/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManager.kt
@@ -26,9 +26,7 @@ class LocationPermissionManager(
     }
 
     suspend fun provideLocationPermission() {
-        if (_permissionState.value == PermissionState.DeniedAlways ||
-            _permissionState.value == PermissionState.NotGranted
-        ) {
+        if (_permissionState.value == PermissionState.DeniedAlways) {
             logger.i(TAG) {
                 "Location is permanently denied. Opening app settings"
             }

--- a/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
+++ b/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import kotlin.test.Test
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 
 class LocationPermissionManagerTest {

--- a/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
+++ b/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
@@ -1,0 +1,70 @@
+package com.foreverrafs.superdiary.core.permission
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.foreverrafs.superdiary.core.logging.AggregateLogger
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+class LocationPermissionManagerTest {
+
+    @Test
+    fun `should request location permission when permission is not granted`() = runTest {
+        val permissionsController = FakePermissionsControllerWrapper(
+            permissionState = PermissionState.NotGranted,
+        )
+        val manager = LocationPermissionManager(
+            permissionsController = permissionsController,
+            logger = AggregateLogger(),
+        )
+
+        manager.permissionState.first()
+        manager.provideLocationPermission()
+
+        assertThat(permissionsController.actionPerformed)
+            .isEqualTo(FakePermissionsControllerWrapper.ActionPerformed.ProvidePermission)
+    }
+
+    @Test
+    fun `should open app settings when location permission is permanently denied`() = runTest {
+        val permissionsController = FakePermissionsControllerWrapper(
+            permissionState = PermissionState.DeniedAlways,
+        )
+        val manager = LocationPermissionManager(
+            permissionsController = permissionsController,
+            logger = AggregateLogger(),
+        )
+
+        manager.permissionState.first()
+        manager.provideLocationPermission()
+
+        assertThat(permissionsController.actionPerformed)
+            .isEqualTo(FakePermissionsControllerWrapper.ActionPerformed.OpenAppSettings)
+    }
+}
+
+private class FakePermissionsControllerWrapper(
+    private val permissionState: PermissionState,
+) : PermissionsControllerWrapper {
+    sealed interface ActionPerformed {
+        data object ProvidePermission : ActionPerformed
+        data object OpenAppSettings : ActionPerformed
+    }
+
+    var actionPerformed: ActionPerformed? = null
+        private set
+
+    override suspend fun providePermission(permission: Permission) {
+        actionPerformed = ActionPerformed.ProvidePermission
+    }
+
+    override suspend fun isPermissionGranted(permission: Permission): Boolean =
+        permissionState == PermissionState.Granted
+
+    override suspend fun getPermissionState(permission: Permission): PermissionState = permissionState
+
+    override fun openAppSettings() {
+        actionPerformed = ActionPerformed.OpenAppSettings
+    }
+}

--- a/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
+++ b/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
@@ -35,7 +35,6 @@ class LocationPermissionManagerTest {
             logger = AggregateLogger(),
         )
 
-        manager.permissionState.first()
         manager.provideLocationPermission()
 
         assertThat(permissionsController.actionPerformed)

--- a/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
+++ b/core/permission/src/commonTest/kotlin/com/foreverrafs/superdiary/core/permission/LocationPermissionManagerTest.kt
@@ -19,7 +19,6 @@ class LocationPermissionManagerTest {
             logger = AggregateLogger(),
         )
 
-        manager.permissionState.first()
         manager.provideLocationPermission()
 
         assertThat(permissionsController.actionPerformed)


### PR DESCRIPTION
## Summary
- Fixes the location permission flow so NotGranted requests the runtime permission dialog instead of opening app settings
- Keeps app settings behavior only for DeniedAlways
- Adds regression coverage for NotGranted and DeniedAlways permission states

## Test Plan
- ./gradlew :core:permission:jvmTest --tests '*LocationPermissionManagerTest*'
- ./gradlew :core:permission:jvmTest
- ./gradlew :core:permission:ktlintCheck
- ./gradlew :feature:create-diary:jvmTest --tests '*CreateDiaryViewModelTest*'