### PR TITLE
Fix empty dashboard loading

### DIFF
--- a/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/domain/GetRecentEntriesUseCase.kt
+++ b/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/domain/GetRecentEntriesUseCase.kt
@@ -7,6 +7,7 @@ import com.foreverrafs.superdiary.data.datasource.Syncable
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.domain.repository.DataSource
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withTimeout
 
 class GetRecentEntriesUseCase(
@@ -29,7 +30,7 @@ class GetRecentEntriesUseCase(
                 }
 
                 logger.i(TAG) { "Sync completed: Fetching latest entries" }
-                dataSource.getLatest(count).first()
+                dataSource.getLatest(count).firstOrNull().orEmpty()
             },
         )
     } catch (e: Exception) {

--- a/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/domain/GetRecentEntriesUseCase.kt
+++ b/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/domain/GetRecentEntriesUseCase.kt
@@ -7,7 +7,6 @@ import com.foreverrafs.superdiary.data.datasource.Syncable
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.domain.repository.DataSource
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withTimeout
 
 class GetRecentEntriesUseCase(
@@ -21,19 +20,16 @@ class GetRecentEntriesUseCase(
 
         Result.Success(
             data = withTimeout(11_000) {
-                flow {
-                    val syncState = dataSource.initialSyncState.first {
-                        it == InitialSyncState.Completed || it == InitialSyncState.Failed
-                    }
+                val syncState = dataSource.initialSyncState.first {
+                    it == InitialSyncState.Completed || it == InitialSyncState.Failed
+                }
 
-                    if (syncState == InitialSyncState.Failed) {
-                        logger.w(TAG) { "Initial sync failed; continuing with local data." }
-                    }
+                if (syncState == InitialSyncState.Failed) {
+                    logger.w(TAG) { "Initial sync failed; continuing with local data." }
+                }
 
-                    logger.i(TAG) { "Sync completed: Fetching latest entries" }
-                    val data = dataSource.getLatest(count).first()
-                    emit(data)
-                }.first { it.isNotEmpty() }
+                logger.i(TAG) { "Sync completed: Fetching latest entries" }
+                dataSource.getLatest(count).first()
             },
         )
     } catch (e: Exception) {

--- a/feature/diary-dashboard/src/commonTest/kotlin/com/foreverrafs/superdiary/dashboard/DashboardViewModelTest.kt
+++ b/feature/diary-dashboard/src/commonTest/kotlin/com/foreverrafs/superdiary/dashboard/DashboardViewModelTest.kt
@@ -2,10 +2,10 @@ package com.foreverrafs.superdiary.dashboard
 
 import app.cash.turbine.test
 import assertk.assertThat
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -177,16 +177,16 @@ class DashboardViewModelTest {
     }
 
     @Test
-    fun `Should show error screen when loading diaries throw an error`() = runTest {
+    fun `Should show empty content when an account has no diaries`() = runTest {
         every { dataSource.getLatest(any()) } returns flowOf(emptyList())
 
         val viewModel = createDashboardViewModel()
 
         viewModel.state.test {
             val state =
-                awaitUntil { it is DashboardViewModel.DashboardScreenState.Error } as DashboardViewModel.DashboardScreenState.Error
+                awaitUntil { it is DashboardViewModel.DashboardScreenState.Content } as DashboardViewModel.DashboardScreenState.Content
 
-            assertThat(state.message).isNotEmpty()
+            assertThat(state.latestEntries).isEmpty()
         }
     }
 

--- a/feature/diary-dashboard/src/commonTest/kotlin/com/foreverrafs/superdiary/dashboard/DashboardViewModelTest.kt
+++ b/feature/diary-dashboard/src/commonTest/kotlin/com/foreverrafs/superdiary/dashboard/DashboardViewModelTest.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -179,6 +180,20 @@ class DashboardViewModelTest {
     @Test
     fun `Should show empty content when an account has no diaries`() = runTest {
         every { dataSource.getLatest(any()) } returns flowOf(emptyList())
+
+        val viewModel = createDashboardViewModel()
+
+        viewModel.state.test {
+            val state =
+                awaitUntil { it is DashboardViewModel.DashboardScreenState.Content } as DashboardViewModel.DashboardScreenState.Content
+
+            assertThat(state.latestEntries).isEmpty()
+        }
+    }
+
+    @Test
+    fun `Should show empty content when the diary flow completes without emitting`() = runTest {
+        every { dataSource.getLatest(any()) } returns emptyFlow()
 
         val viewModel = createDashboardViewModel()
 


### PR DESCRIPTION
## Summary

- treat an empty diary list as a valid synchronized result
- keep the existing timeout for sync or data flows that do not emit
- add regression coverage for accounts with no diary entries

## Testing

- ./gradlew :feature:diary-dashboard:testAndroidHostTest --rerun-tasks
- ./gradlew :feature:diary-dashboard:testAndroidHostTest :feature:diary-dashboard:ktlintCheck
- ./gradlew testAndroidHostTest