### PR TITLE
Propagate sign-out and database failures

### DIFF
--- a/core/database/src/commonMain/kotlin/com/foreverrafs/superdiary/database/Database.kt
+++ b/core/database/src/commonMain/kotlin/com/foreverrafs/superdiary/database/Database.kt
@@ -171,20 +171,16 @@ class Database(
     )
 
     fun update(diary: DiaryDb): Long {
-        try {
-            queries.update(
-                id = diary.id,
-                entry = diary.entry,
-                date = diary.date,
-                favorite = diary.isFavorite.asLong(),
-                location = LocationDb.fromString(diary.location),
-                updated_at = diary.updatedAt,
-                is_synced = diary.isSynced.asLong(),
-                is_marked_for_delete = diary.isMarkedForDelete.asLong(),
-            )
-        } catch (e: Exception) {
-            println(e.message)
-        }
+        queries.update(
+            id = diary.id,
+            entry = diary.entry,
+            date = diary.date,
+            favorite = diary.isFavorite.asLong(),
+            location = LocationDb.fromString(diary.location),
+            updated_at = diary.updatedAt,
+            is_synced = diary.isSynced.asLong(),
+            is_marked_for_delete = diary.isMarkedForDelete.asLong(),
+        )
 
         return queries.getAffectedRows().executeAsOne()
     }

--- a/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/domain/usecase/SignOutUseCase.kt
+++ b/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/domain/usecase/SignOutUseCase.kt
@@ -11,7 +11,11 @@ class SignOutUseCase(
 ) {
     suspend operator fun invoke(): Result<Unit> {
         return try {
-            authApi.signOut()
+            val signOutResult = authApi.signOut()
+            if (signOutResult.isFailure) {
+                return signOutResult
+            }
+
             preferences.clear()
             dataSource.deleteAll()
             dataSource.clearChatMessages()

--- a/feature/diary-profile/src/commonTest/kotlin/com/foreverrafs/superdiary/profile/SignOutUseCaseTest.kt
+++ b/feature/diary-profile/src/commonTest/kotlin/com/foreverrafs/superdiary/profile/SignOutUseCaseTest.kt
@@ -65,6 +65,21 @@ class SignOutUseCaseTest {
         }
 
     @Test
+    fun `should return failure and preserve local data when signOut returns failure`() =
+        runTest(testDispatcher) {
+            val exception = Exception("Auth API failure")
+            everySuspend { authApi.signOut() } returns Result.failure(exception)
+
+            val result = signOutUseCase.invoke()
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(exception)
+            verifySuspend(VerifyMode.exactly(0)) { preferences.clear() }
+            verifySuspend(VerifyMode.exactly(0)) { dataSource.deleteAll() }
+            verifySuspend(VerifyMode.exactly(0)) { dataSource.clearChatMessages() }
+        }
+
+    @Test
     fun `should return failure and stop when preferences clearing fails`() =
         runTest(testDispatcher) {
             val exception = Exception("Preferences clear failure")

--- a/shared-data/src/commonTest/kotlin/com/foreverrafs/superdiary/database/DatabaseTest.kt
+++ b/shared-data/src/commonTest/kotlin/com/foreverrafs/superdiary/database/DatabaseTest.kt
@@ -1,0 +1,22 @@
+package com.foreverrafs.superdiary.database
+
+import com.foreverrafs.superdiary.database.model.DiaryDb
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DatabaseTest {
+    private val database = Database(testSuperDiaryDatabase)
+
+    @Test
+    fun `update propagates invalid diary data errors`() {
+        val diary = DiaryDb(
+            id = 1,
+            entry = "Entry",
+            location = "invalid,location",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            database.update(diary)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- stop local logout cleanup when authentication returns a failure
- propagate database update errors instead of swallowing them
- add regression coverage for both failure paths

## Testing

- `./gradlew :feature:diary-profile:testAndroidHostTest :shared-data:testAndroidHostTest --rerun-tasks`
- `./gradlew :feature:diary-profile:ktlintCheck :core:database:ktlintCheck :shared-data:ktlintCommonTestSourceSetCheck`
- `./gradlew testAndroidHostTest`