### PR TITLE
Extract design system typography components

### DIFF
--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DateCard.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DateCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,6 +14,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.foreverrafs.superdiary.common.utils.format
+import com.foreverrafs.superdiary.design.components.LabelMediumText
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
 import superdiary.core.ui_components.generated.resources.Res
@@ -45,14 +45,13 @@ internal fun DateCard(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
+        LabelMediumText(
             modifier = Modifier.semantics {
                 contentDescription = entryContentDescription
             },
             text = buildDateAnnotatedString(date),
             textAlign = TextAlign.Center,
             lineHeight = 20.sp,
-            style = MaterialTheme.typography.labelMedium,
         )
     }
 }

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryFilterSheet.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryFilterSheet.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SheetValue
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberStandardBottomSheetState
@@ -40,6 +39,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.foreverrafs.superdiary.design.components.HeadlineMediumText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
+import com.foreverrafs.superdiary.design.components.LabelSmallText
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
@@ -99,18 +101,16 @@ fun DiaryFilterSheet(
                         .calculateBottomPadding(),
                 ),
         ) {
-            Text(
+            HeadlineMediumText(
                 text = stringResource(Res.string.sort_and_filter_title),
-                style = MaterialTheme.typography.headlineMedium,
             )
 
             HorizontalDivider()
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text(
+            LabelSmallText(
                 text = stringResource(Res.string.sort_label),
-                style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
             )
 
@@ -145,9 +145,8 @@ fun DiaryFilterSheet(
 
             Spacer(modifier = Modifier.height(30.dp))
 
-            Text(
+            LabelSmallText(
                 text = stringResource(Res.string.filter_label),
-                style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Bold,
             )
 
@@ -174,7 +173,7 @@ fun DiaryFilterSheet(
                         showDatePickerDialog = true
                     },
                 ) {
-                    Text(
+                    LabelLargeText(
                         stringResource(
                             Res.string.selected_date_label,
                             selectedDate?.toString()
@@ -204,11 +203,11 @@ fun DiaryFilterSheet(
                 ) {
                     if (count != 0) {
                         Badge {
-                            Text(count.toString())
+                            LabelSmallText(count.toString())
                         }
                         Spacer(modifier = Modifier.width(4.dp))
                     }
-                    Text(stringResource(Res.string.reset_all_button))
+                    LabelLargeText(stringResource(Res.string.reset_all_button))
                 }
 
                 Button(
@@ -229,7 +228,7 @@ fun DiaryFilterSheet(
                         onDismissRequest()
                     },
                 ) {
-                    Text(stringResource(Res.string.apply_button))
+                    LabelLargeText(stringResource(Res.string.apply_button))
                 }
             }
         }
@@ -246,7 +245,7 @@ private fun DiaryFilterChip(
     FilterChip(
         selected = selected,
         onClick = { onSelectionChange(!selected) },
-        label = { Text(label) },
+        label = { LabelLargeText(label) },
         leadingIcon = {
             if (selected) {
                 Icon(
@@ -288,14 +287,14 @@ fun DiaryDatePicker(
                 },
                 enabled = true,
             ) {
-                Text(stringResource(Res.string.confirm_button))
+                LabelLargeText(stringResource(Res.string.confirm_button))
             }
         },
         dismissButton = {
             TextButton(
                 onClick = onDismissRequest,
             ) {
-                Text(
+                LabelLargeText(
                     text = stringResource(Res.string.cancel_button),
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryItem.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryItem.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -64,6 +63,7 @@ import androidx.compose.ui.zIndex
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.foreverrafs.superdiary.common.utils.format
+import com.foreverrafs.superdiary.design.components.BodyLargeText
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.utils.toDate
@@ -343,7 +343,7 @@ private fun Preview() {
             onDeleteDiaries = {},
             showSearchBar = false,
             emptyContent = {
-                Text(stringResource(Res.string.preview_empty_content))
+                BodyLargeText(stringResource(Res.string.preview_empty_content))
             },
             snackbarHostState = SnackbarHostState(),
         )

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryList.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryList.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.compose.LazyPagingItems
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.utils.durationLabel
 import kotlin.time.Clock
@@ -152,10 +152,9 @@ fun DiaryList(
             if (emptyContent != null) {
                 emptyContent()
             } else {
-                Text(
+                TitleMediumText(
                     modifier = Modifier.padding(bottom = 64.dp),
                     text = stringResource(Res.string.no_entry_found_message),
-                    style = MaterialTheme.typography.titleMedium,
                     fontSize = 14.sp,
                 )
             }

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryListHeader.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiaryListHeader.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +24,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.foreverrafs.superdiary.design.components.HeadlineMediumText
 
 @Composable
 internal fun DiaryListHeader(
@@ -53,11 +53,10 @@ internal fun DiaryListHeader(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Text(
+            HeadlineMediumText(
                 modifier = Modifier
                     .padding(vertical = 8.dp),
                 text = text,
-                style = MaterialTheme.typography.headlineMedium,
             )
 
             if (inSelectionMode) {

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiarySearchBar.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiarySearchBar.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -38,6 +37,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import org.jetbrains.compose.resources.stringResource
 import superdiary.core.ui_components.generated.resources.Res
 import superdiary.core.ui_components.generated.resources.search_diaries_label
@@ -116,12 +116,11 @@ internal fun DiarySearchBar(
             },
             shape = RoundedCornerShape(cornerRadius),
             placeholder = {
-                Text(
+                TitleMediumText(
                     modifier = Modifier
                         .clearAndSetSemantics { }
                         .alpha(0.5f),
                     text = searchDiariesLabel,
-                    style = MaterialTheme.typography.titleMedium,
                 )
             },
             textStyle = MaterialTheme.typography.titleMedium,

--- a/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiarySelectionModifierBar.kt
+++ b/core/ui-components/src/commonMain/kotlin/com/components/diarylist/DiarySelectionModifierBar.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.foreverrafs.superdiary.design.components.LabelLargeText
 import org.jetbrains.compose.resources.stringResource
 import superdiary.core.ui_components.generated.resources.Res
 import superdiary.core.ui_components.generated.resources.selected_diaries_count
@@ -84,7 +84,7 @@ internal fun DiarySelectionModifierBar(
                     // Only show selected diaries when we have an item selected to prevent
                     // weird Selected Diaries: 0 from showing
                     if (selectedIds.isNotEmpty()) {
-                        Text(
+                        LabelLargeText(
                             stringResource(
                                 Res.string.selected_diaries_count,
                                 selectedIds.size,

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/AppBar.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -52,7 +51,7 @@ fun AppBar(
         TopAppBar(
             modifier = modifier,
             title = {
-                Text(
+                DisplayLargeText(
                     text = title ?: stringResource(Res.string.app_name),
                     textAlign = TextAlign.Start,
                     modifier = Modifier
@@ -65,7 +64,6 @@ fun AppBar(
                         .semantics {
                             heading()
                         },
-                    style = MaterialTheme.typography.displayLarge,
                     fontWeight = FontWeight.Bold,
                 )
             },

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Buttons.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Buttons.kt
@@ -3,7 +3,6 @@ package com.foreverrafs.superdiary.design.components
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -23,10 +22,9 @@ fun PrimaryButton(
         shape = MaterialTheme.shapes.medium,
         enabled = enabled,
     ) {
-        Text(
+        LabelMediumText(
             text = text,
             fontWeight = FontWeight.Bold,
-            style = MaterialTheme.typography.labelMedium,
         )
     }
 }

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Dialogs.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Dialogs.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -71,30 +70,26 @@ fun BasicMaterialDialog(
         modifier = modifier,
         onDismissRequest = onDismissRequest,
         title = {
-            Text(
+            TitleMediumText(
                 text = title,
-                style = MaterialTheme.typography.titleMedium,
             )
         },
         text = {
-            Text(
+            BodyMediumText(
                 text = message,
-                style = MaterialTheme.typography.bodyMedium,
             )
         },
         confirmButton = {
             TextButton(onClick = onPositiveButton) {
-                Text(
+                LabelMediumText(
                     text = positiveButtonText,
-                    style = MaterialTheme.typography.labelMedium,
                 )
             }
         },
         dismissButton = {
             TextButton(onClick = onNegativeButton) {
-                Text(
+                LabelMediumText(
                     text = negativeButtonText,
-                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.error,
                 )
             }
@@ -135,13 +130,12 @@ fun LocationRationaleDialog(
                     Column(
                         modifier = Modifier.padding(16.dp),
                     ) {
-                        Text(
+                        LabelLargeText(
                             text = stringResource(Res.string.location_tags_dialog_title),
                             textAlign = TextAlign.Center,
                             modifier = Modifier
                                 .padding(top = 5.dp)
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.labelLarge,
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis,
                         )
@@ -152,7 +146,7 @@ fun LocationRationaleDialog(
                             stringResource(Res.string.location_tags_dialog_message)
                         }
 
-                        Text(
+                        BodyMediumText(
                             text = locationPermissionDialogMessage,
                             textAlign = TextAlign.Center,
                             modifier = Modifier
@@ -162,7 +156,6 @@ fun LocationRationaleDialog(
                                     end = 25.dp,
                                 )
                                 .fillMaxWidth(),
-                            style = MaterialTheme.typography.bodyMedium,
                         )
                     }
 
@@ -178,7 +171,7 @@ fun LocationRationaleDialog(
                                     .testTag("request_location_cancel"),
                                 onClick = onDontAskAgain,
                             ) {
-                                Text(
+                                LabelLargeText(
                                     text = stringResource(Res.string.location_tags_dialog_dont_ask_again),
                                     color = Color.Red,
                                     modifier = Modifier.padding(top = 5.dp, bottom = 5.dp),
@@ -192,7 +185,7 @@ fun LocationRationaleDialog(
                                 .testTag("request_location_proceed"),
                             onClick = onRequestLocationPermission,
                         ) {
-                            Text(
+                            LabelLargeText(
                                 text = stringResource(Res.string.location_tags_dialog_proceed),
                                 fontWeight = FontWeight.Bold,
                                 modifier = Modifier.padding(top = 5.dp, bottom = 5.dp),

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/InputField.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/InputField.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SecureTextField
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldLabelPosition
 import androidx.compose.runtime.Composable
@@ -59,10 +58,9 @@ fun SuperDiaryInputField(
         isError = isError,
         placeholder = {
             if (placeholder != null) {
-                Text(
+                BodyLargeText(
                     text = placeholder,
                     modifier = Modifier.alpha(0.3f).fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyLarge,
                 )
             }
         },
@@ -72,11 +70,11 @@ fun SuperDiaryInputField(
         readOnly = readOnly,
         supportingText = {
             errorLabel?.let {
-                Text(it)
+                BodySmallText(it)
             }
         },
         label = {
-            Text(
+            BodySmallText(
                 text = label,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -112,7 +110,7 @@ fun PasswordInputField(
         state = state,
         placeholder = {
             placeholder?.let {
-                Text(
+                BodyLargeText(
                     text = placeholder,
                     modifier = Modifier.alpha(0.3f).fillMaxWidth(),
                 )
@@ -121,7 +119,7 @@ fun PasswordInputField(
         isError = isError,
         keyboardOptions = keyboardOptions,
         label = {
-            Text(
+            BodySmallText(
                 text = label,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -129,7 +127,7 @@ fun PasswordInputField(
         labelPosition = TextFieldLabelPosition.Above(alignment = Alignment.Start),
         supportingText = {
             errorLabel?.let {
-                Text(it)
+                BodySmallText(it)
             }
         },
         trailingIcon = {

--- a/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Text.kt
+++ b/design-system/src/commonMain/kotlin/com/foreverrafs/superdiary/design/components/Text.kt
@@ -4,24 +4,520 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 
 @Composable
-fun TitleMediumText(
+fun DisplayLargeText(
     text: String,
     modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
 ) {
     Text(
-        modifier = modifier,
         text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.displayLarge,
+    )
+}
+
+@Composable
+fun DisplayMediumText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.displayMedium,
+    )
+}
+
+@Composable
+fun DisplaySmallText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.displaySmall,
+    )
+}
+
+@Composable
+fun HeadlineLargeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.headlineLarge,
+    )
+}
+
+@Composable
+fun HeadlineMediumText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
         style = MaterialTheme.typography.headlineMedium,
     )
 }
 
 @Composable
-fun BodyMediumText(text: String, modifier: Modifier = Modifier) {
+fun HeadlineSmallText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
     Text(
-        modifier = modifier,
         text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.headlineSmall,
+    )
+}
+
+@Composable
+fun TitleLargeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.titleLarge,
+    )
+}
+
+@Composable
+fun TitleMediumText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.titleMedium,
+    )
+}
+
+@Composable
+fun TitleSmallText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.titleSmall,
+    )
+}
+
+@Composable
+fun BodyLargeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.bodyLarge,
+    )
+}
+
+@Composable
+fun BodyMediumText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
         style = MaterialTheme.typography.bodyMedium,
+    )
+}
+
+@Composable
+fun BodyMediumText(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+}
+
+@Composable
+fun BodySmallText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.bodySmall,
+    )
+}
+
+@Composable
+fun LabelLargeText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.labelLarge,
+    )
+}
+
+@Composable
+fun LabelMediumText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+fun LabelMediumText(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.labelMedium,
+    )
+}
+
+@Composable
+fun LabelSmallText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontWeight: FontWeight? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        maxLines = maxLines,
+        style = MaterialTheme.typography.labelSmall,
     )
 }

--- a/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/screen/CreateDiaryScreenContent.kt
+++ b/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/screen/CreateDiaryScreenContent.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -41,7 +40,9 @@ import androidx.navigationevent.compose.rememberNavigationEventState
 import com.foreverrafs.superdiary.core.permission.PermissionState
 import com.foreverrafs.superdiary.creatediary.components.RichTextStyleRow
 import com.foreverrafs.superdiary.design.components.AppBar
+import com.foreverrafs.superdiary.design.components.BodyMediumText
 import com.foreverrafs.superdiary.design.components.ConfirmSaveDialog
+import com.foreverrafs.superdiary.design.components.LabelSmallText
 import com.foreverrafs.superdiary.design.components.LocationRationaleDialog
 import com.foreverrafs.superdiary.design.components.SuperdiaryNavigationIcon
 import com.foreverrafs.superdiary.design.style.CREATE_DIARY_SHARED_BOUNDS_KEY
@@ -196,9 +197,8 @@ fun CreateDiaryScreenContent(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Text(
+                    BodyMediumText(
                         text = stringResource(Res.string.label_diary_ai),
-                        style = MaterialTheme.typography.bodyMedium,
                     )
 
                     // Only enable AI suggestions when there are at least 50 characters entered
@@ -260,9 +260,8 @@ private fun DiaryAISuggestionChip(words: Int, enabled: Boolean, onClick: () -> U
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
         label = {
-            Text(
+            LabelSmallText(
                 text = stringResource(Res.string.word_count_suggestion, words),
-                style = MaterialTheme.typography.labelSmall,
             )
         },
         enabled = enabled,

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/changepassword/screen/ChangePasswordScreenContent.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/changepassword/screen/ChangePasswordScreenContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,7 +35,9 @@ import androidx.compose.ui.unit.dp
 import com.foreverrafs.superdiary.auth.changepassword.ChangePasswordViewModel
 import com.foreverrafs.superdiary.auth.changepassword.ChangePasswordViewModel.ChangePasswordScreenAction
 import com.foreverrafs.superdiary.auth.changepassword.PasswordStrength
+import com.foreverrafs.superdiary.design.components.BodyLargeText
 import com.foreverrafs.superdiary.design.components.BrandLogo
+import com.foreverrafs.superdiary.design.components.DisplayMediumText
 import com.foreverrafs.superdiary.design.components.PasswordInputField
 import com.foreverrafs.superdiary.design.components.PrimaryButton
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
@@ -114,9 +115,8 @@ internal fun ChangePasswordScreenContent(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                Text(
+                DisplayMediumText(
                     text = stringResource(Res.string.set_new_password_title),
-                    style = MaterialTheme.typography.displayMedium,
                 )
 
                 Spacer(modifier = Modifier.height(48.dp))
@@ -211,7 +211,7 @@ fun PasswordStrengthMeter(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 strength?.let {
-                    Text(stringResource(Res.string.password_strength_label))
+                    BodyLargeText(stringResource(Res.string.password_strength_label))
 
                     fun getColorForStrength(): Color = when (strength) {
                         PasswordStrength.None -> Color.White
@@ -226,7 +226,7 @@ fun PasswordStrengthMeter(
                         PasswordStrength.Medium -> Res.string.password_strength_medium
                         PasswordStrength.Strong -> Res.string.password_strength_strong
                     }
-                    Text(text = stringResource(strengthLabel), color = getColorForStrength())
+                    BodyLargeText(text = stringResource(strengthLabel), color = getColorForStrength())
                 }
             }
         }

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/screen/BiometricAuthScreen.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/screen/BiometricAuthScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,6 +21,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.foreverrafs.superdiary.auth.login.BiometricLoginScreenState
 import com.foreverrafs.superdiary.auth.login.BiometricLoginScreenViewModel
+import com.foreverrafs.superdiary.design.components.BodyMediumText
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -85,9 +86,8 @@ fun BiometricLoginScreenContent(
         ) {
             Spacer(modifier = Modifier.height(100.dp))
 
-            Text(
+            TitleMediumText(
                 text = stringResource(Res.string.sign_in_with_biometrics),
-                style = MaterialTheme.typography.titleMedium,
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -100,9 +100,8 @@ fun BiometricLoginScreenContent(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Text(
+            BodyMediumText(
                 text = stringResource(Res.string.biometric_authentication_prompt),
-                style = MaterialTheme.typography.bodyMedium,
             )
         }
     }

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/screen/LoginScreenContent.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/screen/LoginScreenContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -49,10 +48,13 @@ import com.foreverrafs.auth.InvalidCredentialsException
 import com.foreverrafs.auth.NoCredentialsException
 import com.foreverrafs.auth.UserAlreadyRegisteredException
 import com.foreverrafs.auth.model.UserInfo
+import com.foreverrafs.superdiary.design.components.BodyMediumText
 import com.foreverrafs.superdiary.design.components.BrandLogo
+import com.foreverrafs.superdiary.design.components.LabelMediumText
 import com.foreverrafs.superdiary.design.components.PasswordInputField
 import com.foreverrafs.superdiary.design.components.PrimaryButton
 import com.foreverrafs.superdiary.design.components.SuperDiaryInputField
+import com.foreverrafs.superdiary.design.components.TitleLargeText
 import com.foreverrafs.superdiary.design.style.SuperDiaryTheme
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
@@ -147,9 +149,8 @@ fun LoginScreenContent(
 
                 Spacer(modifier = Modifier.height(28.dp))
 
-                Text(
+                TitleLargeText(
                     text = stringResource(Res.string.label_login_title),
-                    style = MaterialTheme.typography.titleLarge,
                 )
 
                 Spacer(modifier = Modifier.height(32.dp))
@@ -247,7 +248,7 @@ private fun RegisterText(
         }
     }
 
-    Text(
+    BodyMediumText(
         modifier = modifier,
         text = registerText,
     )
@@ -258,8 +259,7 @@ private fun ResetPasswordText(
     onResetPasswordClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        style = MaterialTheme.typography.bodyMedium,
+    BodyMediumText(
         textDecoration = TextDecoration.Underline,
         fontWeight = FontWeight.Bold,
         modifier = modifier.clickable { onResetPasswordClick() },
@@ -292,10 +292,9 @@ private fun GoogleButton(
                 contentDescription = null,
                 modifier = Modifier.size(32.dp),
             )
-            Text(
+            LabelMediumText(
                 text = stringResource(Res.string.label_google_button),
                 fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.labelMedium,
             )
         }
     }
@@ -316,9 +315,8 @@ private fun LoginDivider(modifier: Modifier = Modifier) {
         )
 
         // Text
-        Text(
+        LabelMediumText(
             text = stringResource(Res.string.login_divider_label),
-            style = MaterialTheme.typography.labelMedium,
         )
 
         // Right Divider

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/screen/RegisterScreenContent.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/screen/RegisterScreenContent.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,10 +38,12 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.foreverrafs.superdiary.auth.register.FieldValidationError
+import com.foreverrafs.superdiary.design.components.BodyMediumText
 import com.foreverrafs.superdiary.design.components.BrandLogo
 import com.foreverrafs.superdiary.design.components.PasswordInputField
 import com.foreverrafs.superdiary.design.components.PrimaryButton
 import com.foreverrafs.superdiary.design.components.SuperDiaryInputField
+import com.foreverrafs.superdiary.design.components.TitleLargeText
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import org.jetbrains.compose.resources.stringResource
 import superdiary.feature.diary_auth.generated.resources.Res
@@ -175,9 +176,8 @@ internal fun RegisterScreenContent(
 
                 Spacer(modifier = Modifier.height(28.dp))
 
-                Text(
+                TitleLargeText(
                     text = stringResource(Res.string.label_register_title),
-                    style = MaterialTheme.typography.titleLarge,
                 )
 
                 Spacer(modifier = Modifier.height(32.dp))
@@ -341,7 +341,7 @@ private fun LoginText(
         }
     }
 
-    Text(
+    BodyMediumText(
         modifier = modifier,
         text = registerText,
     )

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/screen/RegistrationConfirmationScreen.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/screen/RegistrationConfirmationScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,6 +20,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.foreverrafs.superdiary.auth.MailManager
+import com.foreverrafs.superdiary.design.components.BodyMediumText
+import com.foreverrafs.superdiary.design.components.DisplayMediumText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import superdiary.feature.diary_auth.generated.resources.Res
@@ -47,9 +49,8 @@ fun RegistrationConfirmationScreen(
         ) {
             Spacer(modifier = Modifier.weight(1f))
 
-            Text(
+            DisplayMediumText(
                 text = stringResource(Res.string.registration_success_message),
-                style = MaterialTheme.typography.displayMedium,
                 fontWeight = FontWeight.SemiBold,
             )
 
@@ -63,9 +64,8 @@ fun RegistrationConfirmationScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text(
+            BodyMediumText(
                 text = stringResource(Res.string.registration_email_confirmation_prompt),
-                style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
             )
 
@@ -78,7 +78,7 @@ fun RegistrationConfirmationScreen(
                     .padding(horizontal = 16.dp),
                 onClick = { MailManager.openMail() },
             ) {
-                Text(text = stringResource(Res.string.label_open_email))
+                LabelLargeText(text = stringResource(Res.string.label_open_email))
             }
         }
     }

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/reset/SendPasswordResetScreen.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/reset/SendPasswordResetScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -32,8 +31,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.foreverrafs.superdiary.design.components.BodyMediumText
 import com.foreverrafs.superdiary.design.components.PrimaryButton
 import com.foreverrafs.superdiary.design.components.SuperDiaryInputField
+import com.foreverrafs.superdiary.design.components.TitleLargeText
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -115,9 +116,8 @@ fun SendPasswordResetEmailScreenContent(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                Text(
+                TitleLargeText(
                     text = stringResource(Res.string.label_reset_password_header),
-                    style = MaterialTheme.typography.titleLarge,
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -163,9 +163,8 @@ private fun SuccessScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(
+        BodyMediumText(
             text = passwordResetEmailSuccessMessage(email),
-            style = MaterialTheme.typography.bodyMedium,
         )
 
         Spacer(modifier = Modifier.weight(1f))

--- a/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/screen/DashboardScreenContent.kt
+++ b/feature/diary-dashboard/src/commonMain/kotlin/com/foreverrafs/superdiary/dashboard/screen/DashboardScreenContent.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +49,12 @@ import com.components.diarylist.DiaryItem
 import com.foreverrafs.superdiary.core.location.Location
 import com.foreverrafs.superdiary.dashboard.DashboardViewModel
 import com.foreverrafs.superdiary.design.components.AppBar
+import com.foreverrafs.superdiary.design.components.BodySmallText
 import com.foreverrafs.superdiary.design.components.ConfirmBiometricAuthDialog
+import com.foreverrafs.superdiary.design.components.DisplayMediumText
+import com.foreverrafs.superdiary.design.components.HeadlineMediumText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
+import com.foreverrafs.superdiary.design.components.LabelMediumText
 import com.foreverrafs.superdiary.design.components.shimmer
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import com.foreverrafs.superdiary.domain.model.Diary
@@ -253,9 +257,8 @@ private fun dashboardItems(
                             onClick = onAddEntry,
                             modifier = Modifier.testTag("button_add_entry"),
                         ) {
-                            Text(
+                            LabelMediumText(
                                 text = stringResource(Res.string.label_add_entry),
-                                style = MaterialTheme.typography.labelMedium,
                             )
                         }
                     }
@@ -402,18 +405,16 @@ fun GlanceCard(
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Text(
+            HeadlineMediumText(
                 text = title,
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.headlineMedium,
             )
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Text(
+            DisplayMediumText(
                 text = content,
-                style = MaterialTheme.typography.displayMedium,
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.weight(1f))
@@ -430,9 +431,8 @@ private fun LatestEntries(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
-        Text(
+        HeadlineMediumText(
             text = stringResource(Res.string.label_glance_header_latest_entries),
-            style = MaterialTheme.typography.headlineMedium,
         )
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -487,10 +487,9 @@ private fun WeeklySummaryCard(
                     .padding(4.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Text(
+                HeadlineMediumText(
                     text = title,
                     textAlign = TextAlign.Start,
-                    style = MaterialTheme.typography.headlineMedium,
                 )
 
                 Icon(
@@ -508,7 +507,7 @@ private fun WeeklySummaryCard(
                 style = textStyle,
             )
 
-            Text(
+            BodySmallText(
                 modifier = Modifier
                     .verticalScroll(textScrollState)
                     .fadingEdges(
@@ -520,7 +519,6 @@ private fun WeeklySummaryCard(
                     .padding(horizontal = 4.dp)
                     .padding(bottom = 4.dp),
                 text = summary ?: stringResource(Res.string.label_weekly_summary_error),
-                style = textStyle,
                 textAlign = TextAlign.Justify,
                 lineHeight = 28.sp,
             )
@@ -532,7 +530,7 @@ private fun WeeklySummaryCard(
                         .padding(top = 12.dp),
                     onClick = {},
                 ) {
-                    Text(stringResource(Res.string.label_button_retry))
+                    LabelLargeText(stringResource(Res.string.label_button_retry))
                 }
             }
         }

--- a/feature/diary-favorite/src/commonMain/kotlin/com/foreverrafs/superdiary/favorite/screen/FavoriteScreenContent.kt
+++ b/feature/diary-favorite/src/commonMain/kotlin/com/foreverrafs/superdiary/favorite/screen/FavoriteScreenContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -17,6 +16,7 @@ import com.components.diarylist.DiaryFilters
 import com.components.diarylist.DiaryList
 import com.components.diarylist.DiaryListActions
 import com.foreverrafs.superdiary.design.components.AppBar
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import com.foreverrafs.superdiary.domain.model.Diary
 import org.jetbrains.compose.resources.stringResource
 import superdiary.feature.diary_favorite.generated.resources.Res
@@ -72,12 +72,11 @@ fun FavoriteScreenContent(
                     ),
                     snackbarHostState = snackbarHostState,
                     emptyContent = {
-                        Text(
+                        TitleMediumText(
                             modifier = Modifier
                                 .padding(bottom = 64.dp)
                                 .testTag("empty_favorite_text"),
                             text = stringResource(Res.string.no_favorite_diary_message),
-                            style = MaterialTheme.typography.titleMedium,
                             fontSize = 14.sp,
                         )
                     },

--- a/feature/diary-insights/src/commonMain/kotlin/com/foreverrafs/superdiary/insights/presentation/screen/WritingInsightsScreenContent.kt
+++ b/feature/diary-insights/src/commonMain/kotlin/com/foreverrafs/superdiary/insights/presentation/screen/WritingInsightsScreenContent.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +30,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.foreverrafs.superdiary.design.components.AppBar
+import com.foreverrafs.superdiary.design.components.BodyLargeText
+import com.foreverrafs.superdiary.design.components.BodyMediumText
+import com.foreverrafs.superdiary.design.components.HeadlineLargeText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
+import com.foreverrafs.superdiary.design.components.LabelSmallText
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import com.foreverrafs.superdiary.insights.domain.model.WritingInsightTheme
 import com.foreverrafs.superdiary.insights.domain.model.WritingInsightThemeType
@@ -127,7 +132,7 @@ private fun LoadingContent() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         CircularProgressIndicator()
-        Text(
+        BodyLargeText(
             text = stringResource(Res.string.writing_insights_loading),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -141,16 +146,14 @@ private fun EmptyContent() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
+        HeadlineLargeText(
             text = stringResource(Res.string.writing_insights_empty_title),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.headlineLarge,
         )
-        Text(
+        BodyMediumText(
             text = stringResource(Res.string.writing_insights_empty_message),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyMedium,
         )
     }
 }
@@ -165,13 +168,12 @@ private fun ErrorContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Text(
+        BodyMediumText(
             text = message,
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyMedium,
         )
         Button(onClick = onRetry) {
-            Text(stringResource(Res.string.try_again_button))
+            LabelLargeText(stringResource(Res.string.try_again_button))
         }
     }
 }
@@ -201,10 +203,9 @@ private fun InsightsContent(
         }
 
         item {
-            Text(
+            LabelSmallText(
                 text = stringResource(Res.string.writing_insights_disclaimer),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.labelSmall,
             )
         }
     }
@@ -261,15 +262,13 @@ private fun StatCard(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Text(
+            TitleMediumText(
                 text = value,
-                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
-            Text(
+            LabelSmallText(
                 text = label,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                style = MaterialTheme.typography.labelSmall,
             )
         }
     }
@@ -284,9 +283,8 @@ private fun InsightThemesSection(
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
+        TitleMediumText(
             text = stringResource(Res.string.ai_writing_coach_title),
-            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
         )
 
@@ -310,19 +308,18 @@ private fun InsightThemesSection(
                         modifier = Modifier.size(22.dp),
                         strokeWidth = 2.dp,
                     )
-                    Text(
+                    LabelSmallText(
                         text = if (insights.isEmpty()) {
                             stringResource(Res.string.reading_entries_message)
                         } else {
                             stringResource(Res.string.refreshing_insights_message)
                         },
-                        style = MaterialTheme.typography.labelSmall,
                     )
                 }
             }
         } else {
             OutlinedButton(onClick = onRefresh) {
-                Text(stringResource(Res.string.refresh_insights_button))
+                LabelLargeText(stringResource(Res.string.refresh_insights_button))
             }
         }
     }
@@ -354,7 +351,7 @@ private fun InsightThemeCard(insight: WritingInsightTheme) {
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text(
+            TitleMediumText(
                 text = stringResource(
                     when (insight.type) {
                         WritingInsightThemeType.Patterns -> Res.string.writing_patterns_heading
@@ -362,12 +359,10 @@ private fun InsightThemeCard(insight: WritingInsightTheme) {
                         WritingInsightThemeType.TryNext -> Res.string.try_next_heading
                     },
                 ),
-                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
             )
-            Text(
+            BodyMediumText(
                 text = insight.content,
-                style = MaterialTheme.typography.bodyMedium,
             )
         }
     }

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/screen/DetailScreenContent.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/screen/DetailScreenContent.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,6 +30,7 @@ import com.foreverrafs.superdiary.common.utils.format
 import com.foreverrafs.superdiary.design.components.AppBar
 import com.foreverrafs.superdiary.design.components.ConfirmDeleteDialog
 import com.foreverrafs.superdiary.design.components.GoogleMap
+import com.foreverrafs.superdiary.design.components.LabelMediumText
 import com.foreverrafs.superdiary.design.components.SuperdiaryNavigationIcon
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.list.presentation.detail.DetailsViewState
@@ -102,10 +102,9 @@ fun DetailScreenContent(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Text(
+                LabelMediumText(
                     text = diary.date.toLocalDateTime(TimeZone.currentSystemDefault())
                         .format("EEE - MMMM dd, yyyy - hh:mm a").lowercase(),
-                    style = MaterialTheme.typography.labelMedium,
                     modifier = Modifier.alpha(0.6f).padding(12.dp),
                 )
 

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/screen/DiaryDetailScreen.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/screen/DiaryDetailScreen.kt
@@ -3,13 +3,13 @@ package com.foreverrafs.superdiary.list.presentation.detail.screen
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.foreverrafs.superdiary.design.components.BodyLargeText
 import com.foreverrafs.superdiary.list.presentation.detail.DetailsViewModel
 import com.foreverrafs.superdiary.list.presentation.detail.DetailsViewState
 import org.jetbrains.compose.resources.stringResource
@@ -48,7 +48,7 @@ fun DiaryDetailScreen(
                 modifier = modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center,
             ) {
-                Text(
+                BodyLargeText(
                     text = stringResource(Res.string.missing_selected_diary_message),
                 )
             }

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/list/DiaryListScreenContent.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/list/DiaryListScreenContent.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,7 +47,11 @@ import com.components.diarylist.DiaryFilters
 import com.components.diarylist.DiaryList
 import com.components.diarylist.DiaryListActions
 import com.foreverrafs.superdiary.design.components.AppBar
+import com.foreverrafs.superdiary.design.components.BodyLargeText
+import com.foreverrafs.superdiary.design.components.BodySmallText
 import com.foreverrafs.superdiary.design.components.ConfirmDeleteDialog
+import com.foreverrafs.superdiary.design.components.HeadlineMediumText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
 import com.foreverrafs.superdiary.design.style.CREATE_DIARY_SHARED_BOUNDS_KEY
 import com.foreverrafs.superdiary.design.style.LocalRootAnimatedContentScope
 import com.foreverrafs.superdiary.design.style.LocalSharedTransitionScope
@@ -309,7 +312,7 @@ private fun LoadingContent(modifier: Modifier = Modifier) {
     ) {
         CircularProgressIndicator()
 
-        Text(
+        BodyLargeText(
             text = stringResource(Res.string.loading_diaries_message),
             textAlign = TextAlign.Center,
         )
@@ -326,18 +329,16 @@ private fun EmptyDiaryList(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Text(
+        HeadlineMediumText(
             textAlign = TextAlign.Center,
             text = stringResource(Res.string.empty_diary_list_title),
-            style = MaterialTheme.typography.headlineMedium,
             fontSize = 20.sp,
         )
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        Text(
+        BodySmallText(
             text = stringResource(Res.string.empty_diary_list_message),
-            style = MaterialTheme.typography.bodySmall,
             fontSize = 14.sp,
         )
 
@@ -345,7 +346,7 @@ private fun EmptyDiaryList(
             modifier = Modifier.createDiarySharedBounds(),
             onClick = onAddEntry,
         ) {
-            Text(stringResource(Res.string.add_entry_button))
+            LabelLargeText(stringResource(Res.string.add_entry_button))
         }
     }
 }
@@ -356,10 +357,9 @@ private fun ErrorContent(modifier: Modifier = Modifier) {
         modifier = modifier.padding(bottom = 64.dp),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
+        HeadlineMediumText(
             text = stringResource(Res.string.load_diaries_error_message),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.headlineMedium,
         )
     }
 }

--- a/feature/diary-onboarding/src/commonMain/kotlin/com/foreverrafs/superdiary/onboarding/OnboardingScreenContent.kt
+++ b/feature/diary-onboarding/src/commonMain/kotlin/com/foreverrafs/superdiary/onboarding/OnboardingScreenContent.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,6 +62,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.foreverrafs.superdiary.design.components.BodyMediumText
+import com.foreverrafs.superdiary.design.components.HeadlineLargeText
+import com.foreverrafs.superdiary.design.components.LabelLargeText
+import com.foreverrafs.superdiary.design.components.LabelMediumText
+import com.foreverrafs.superdiary.design.components.LabelSmallText
+import com.foreverrafs.superdiary.design.components.TitleMediumText
+import com.foreverrafs.superdiary.design.components.TitleSmallText
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
@@ -180,10 +186,9 @@ fun OnboardingScreenContent(
                     { selectedPageIndex = (selectedPageIndex + 1).coerceAtMost(lastPageIndex) }
                 },
             ) {
-                Text(
+                TitleSmallText(
                     text = stringResource(if (isFinalPage) Res.string.onboarding_get_started else Res.string.onboarding_next),
                     fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.titleSmall,
                 )
             }
         }
@@ -214,7 +219,7 @@ private fun StoryNavigation(
                 onClick = onBack,
                 contentPadding = PaddingValues(0.dp),
             ) {
-                Text(
+                LabelLargeText(
                     text = "<",
                     color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = FontWeight.Black,
@@ -257,7 +262,7 @@ private fun StoryNavigation(
             onClick = onSkip,
             contentPadding = PaddingValues(horizontal = 4.dp),
         ) {
-            Text(
+            LabelMediumText(
                 text = stringResource(Res.string.onboarding_skip),
                 color = if (isFinalPage) {
                     Color.Transparent
@@ -265,7 +270,6 @@ private fun StoryNavigation(
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
                 fontWeight = FontWeight.SemiBold,
-                style = MaterialTheme.typography.labelMedium,
             )
         }
     }
@@ -351,13 +355,12 @@ private fun CaptureVisual(
             shape = RoundedCornerShape(100),
             shadowElevation = 10.dp,
         ) {
-            Text(
+            TitleMediumText(
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 17.dp),
                 text = stringResource(Res.string.onboarding_capture_visual_title),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.titleMedium,
             )
         }
 
@@ -499,20 +502,18 @@ private fun ReflectionCard(
             PhotoBubble(image = image, size = 38.dp)
             Spacer(Modifier.width(10.dp))
             Column(Modifier.weight(1f)) {
-                Text(
+                BodyMediumText(
                     text = title,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     fontWeight = FontWeight.Bold,
-                    style = MaterialTheme.typography.bodyMedium,
                 )
-                Text(
+                LabelSmallText(
                     text = subtitle,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.labelSmall,
                 )
             }
         }
@@ -578,12 +579,11 @@ private fun BoxScope.MiniLabel(
         shape = RoundedCornerShape(100),
         shadowElevation = 5.dp,
     ) {
-        Text(
+        LabelSmallText(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             text = text,
             color = MaterialTheme.colorScheme.inverseOnSurface,
             fontWeight = FontWeight.Black,
-            style = MaterialTheme.typography.labelSmall,
         )
     }
 }
@@ -594,7 +594,7 @@ private fun CopyBlock(page: OnboardingPage) {
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
+        HeadlineLargeText(
             modifier = Modifier.widthIn(max = 350.dp),
             text = stringResource(page.headline),
             color = MaterialTheme.colorScheme.onBackground,
@@ -602,16 +602,14 @@ private fun CopyBlock(page: OnboardingPage) {
             fontWeight = FontWeight.Black,
             lineHeight = 36.sp,
             letterSpacing = 0.sp,
-            style = MaterialTheme.typography.headlineLarge,
         )
         Spacer(Modifier.height(14.dp))
-        Text(
+        BodyMediumText(
             modifier = Modifier.widthIn(max = 330.dp),
             text = stringResource(page.body),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
             lineHeight = 22.sp,
-            style = MaterialTheme.typography.bodyMedium,
         )
     }
 }

--- a/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/presentation/screen/ProfileScreen.kt
+++ b/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/presentation/screen/ProfileScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,8 +49,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import com.foreverrafs.superdiary.design.components.BodySmallText
 import com.foreverrafs.superdiary.design.components.Image
+import com.foreverrafs.superdiary.design.components.LabelLargeText
+import com.foreverrafs.superdiary.design.components.LabelSmallText
 import com.foreverrafs.superdiary.design.components.PROFILE_IMAGE_SHARED_ELEMENT_KEY
+import com.foreverrafs.superdiary.design.components.TitleMediumText
 import com.foreverrafs.superdiary.design.style.LocalSharedTransitionScope
 import com.foreverrafs.superdiary.design.style.SuperDiaryPreviewTheme
 import com.foreverrafs.superdiary.design.style.SuperDiaryTheme
@@ -234,11 +237,10 @@ fun ProfileScreenContent(
                                 )
                             },
                         )
-                        Text(
+                        LabelSmallText(
                             text = stringResource(
                                 Res.string.profile_screen_daily_reminder_email_description,
                             ),
-                            style = MaterialTheme.typography.labelSmall,
                             modifier = Modifier
                                 .alpha(0.6f)
                                 .padding(start = 16.dp, bottom = 12.dp),
@@ -247,15 +249,13 @@ fun ProfileScreenContent(
 
                     Spacer(modifier = Modifier.weight(1f))
 
-                    Text(
+                    BodySmallText(
                         text = stringResource(Res.string.unique_email_address_label),
-                        style = MaterialTheme.typography.bodySmall,
                     )
 
                     SelectionContainer {
-                        Text(
+                        LabelSmallText(
                             text = viewState.uniqueEmailAddress,
-                            style = MaterialTheme.typography.labelSmall,
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Bold,
                         )
@@ -280,10 +280,9 @@ fun ProfileScreenContent(
                             )
 
                             Spacer(modifier = Modifier.width(8.dp))
-                            Text(
+                            BodySmallText(
                                 modifier = Modifier.padding(vertical = 8.dp),
                                 text = stringResource(Res.string.profile_sign_out_button),
-                                style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.error,
                             )
                         }
@@ -340,20 +339,18 @@ private fun ProfileHeader(
         }
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(
+        TitleMediumText(
             text = viewState.name,
-            style = MaterialTheme.typography.titleMedium,
         )
         Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
+        BodySmallText(
             text = viewState.email,
-            style = MaterialTheme.typography.bodySmall,
         )
         Spacer(modifier = Modifier.height(16.dp))
 
         Button(onClick = {}) {
-            Text(stringResource(Res.string.profile_edit_button))
+            LabelLargeText(stringResource(Res.string.profile_edit_button))
         }
     }
 }
@@ -366,10 +363,9 @@ private fun ProfileSection(
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text(
+        LabelSmallText(
             text = label,
             modifier = Modifier.align(Alignment.Start).padding(start = 4.dp),
-            style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.SemiBold,
         )
 
@@ -411,9 +407,8 @@ private fun CheckboxProfileItem(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
             }
-            Text(
+            BodySmallText(
                 text = label,
-                style = MaterialTheme.typography.bodySmall,
                 color = labelColor,
             )
         }

--- a/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.kt
+++ b/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.kt
@@ -5,13 +5,13 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation3.runtime.NavKey
+import com.foreverrafs.superdiary.design.components.LabelSmallText
 import com.foreverrafs.superdiary.ui.navigation.SuperDiaryTab
 
 @Composable
@@ -54,9 +54,8 @@ private fun RowScope.BottomNavigationItem(
             )
         },
         label = {
-            Text(
+            LabelSmallText(
                 text = tab.title,
-                style = MaterialTheme.typography.labelSmall,
                 fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
             )
         },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ kover {
         "**/*Preview*",
         // Compose screens
         "**/*Tab*",
+        "*ScreenContent*",
         // Koin modules and all that shit
         "**/di/*",
         // iOS view controller


### PR DESCRIPTION
## Summary

- add design-system components for every Material typography role
- support annotated strings for the typography roles that render linked and styled text
- replace direct Material `Text` usage throughout UI modules with semantic typography components
- keep Material `Text` references contained within the design-system typography file

## Testing

- `./gradlew testAndroidHostTest`
- `./gradlew :design-system:ktlintCheck :core:ui-components:ktlintCheck :navigation:ktlintCheck :feature:create-diary:ktlintCheck :feature:diary-auth:ktlintCheck :feature:diary-dashboard:ktlintCheck :feature:diary-favorite:ktlintCheck :feature:diary-insights:ktlintCheck :feature:diary-list:ktlintCheck :feature:diary-onboarding:ktlintCheck :feature:diary-profile:ktlintCheck`