### PR TITLE
Handle missing Google credentials without crashing

### DIFF
--- a/core/authentication/src/androidMain/kotlin/com/foreverrafs/auth/AndroidAuth.kt
+++ b/core/authentication/src/androidMain/kotlin/com/foreverrafs/auth/AndroidAuth.kt
@@ -8,6 +8,7 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialException
 import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
 import androidx.credentials.exceptions.GetCredentialUnknownException
 import androidx.credentials.exceptions.NoCredentialException
 import com.foreverrafs.superdiary.core.SuperDiarySecret
@@ -26,7 +27,7 @@ class AndroidAuth(
     logger = logger,
 ) {
     /** Use the credentials manager to sign in with Google on Android */
-    override suspend fun signInWithGoogle(): AuthApi.SessionStatus {
+    override suspend fun signInWithGoogle(): AuthApi.SessionStatus = try {
         logger.d(TAG) { "Starting Google sign-in process with CredentialManager" }
         // This must be an activity context
         val hostActivityContext = contextProvider.getContext()
@@ -45,29 +46,39 @@ class AndroidAuth(
             ).build(),
         ).build()
 
-        val googleIdToken = try {
-            logger.d(TAG) { "Requesting credentials from CredentialManager" }
-            val result = credentialManager.getCredential(
-                request = request,
-                context = hostActivityContext,
-            )
+        logger.d(TAG) { "Requesting credentials from CredentialManager" }
+        val result = credentialManager.getCredential(
+            request = request,
+            context = hostActivityContext,
+        )
 
-            getGoogleIdToken(result)
-        } catch (e: GetCredentialException) {
-            logger.e(TAG) { "Error Getting credentials: ${e.message}" }
-            return AuthApi.SessionStatus.Unauthenticated(resolveCredentialException(e))
-        } catch (e: GoogleIdTokenParsingException) {
-            logger.e(TAG) { "Error parsing Google ID token: ${e.message}" }
-            return AuthApi.SessionStatus.Unauthenticated(e)
-        }
+        val googleIdToken = getGoogleIdToken(result)
 
-        return if (googleIdToken != null) {
+        if (googleIdToken != null) {
             logger.d(TAG) { "Google ID token successfully retrieved. Attempting Supabase sign-in." }
             signInWithGoogle(googleIdToken)
         } else {
             logger.e(TAG) { "Google ID token retrieval failed. No token available for sign-in." }
             AuthApi.SessionStatus.Unauthenticated(Exception("Error logging in with Google"))
         }
+    } catch (e: GetCredentialProviderConfigurationException) {
+        // The dependency can be packaged correctly while the device still has no usable
+        // Credential Manager provider (for example, an AOSP emulator without Play Services).
+        logger.w(TAG, e) {
+            "No Credential Manager provider is available on this device"
+        }
+        AuthApi.SessionStatus.Unauthenticated(
+            NoCredentialsException("Google sign-in is not available on this device"),
+        )
+    } catch (e: GetCredentialException) {
+        // NoCredentialException is the expected result when the device has no Google account.
+        // Keep every Credential Manager operation inside this boundary so it cannot escape to
+        // the ViewModel's coroutine as an uncaught exception.
+        logger.e(TAG) { "Error getting credentials: ${e.message}" }
+        AuthApi.SessionStatus.Unauthenticated(resolveCredentialException(e))
+    } catch (e: GoogleIdTokenParsingException) {
+        logger.e(TAG) { "Error parsing Google ID token: ${e.message}" }
+        AuthApi.SessionStatus.Unauthenticated(e)
     }
 
     private fun resolveCredentialException(e: GetCredentialException): Exception = when (e) {

--- a/core/authentication/src/commonMain/kotlin/com/foreverrafs/auth/DefaultSupabaseAuth.kt
+++ b/core/authentication/src/commonMain/kotlin/com/foreverrafs/auth/DefaultSupabaseAuth.kt
@@ -17,10 +17,12 @@ import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.exceptions.RestException
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 
@@ -102,7 +104,7 @@ class DefaultSupabaseAuth(
             logger.i(Tag) {
                 "Waiting for session to be initialized"
             }
-            delay(100)
+            delay(100.milliseconds)
         }
 
         logger.i(Tag) {
@@ -175,7 +177,11 @@ class DefaultSupabaseAuth(
             return
         }
 
-        val charset = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        val charset = (
+            ('A'..'Z')
+                .plusElement(('a'..'z'))
+            )
+            .plusElement(('0'..'9'))
         val randomPart = (1..16)
             .map { charset.random() }
             .joinToString("")
@@ -221,7 +227,7 @@ class DefaultSupabaseAuth(
 
     @OptIn(SupabaseInternal::class)
     override suspend fun handleAuthDeeplink(deeplinkUri: Uri?): AuthApi.SessionStatus =
-        suspendCoroutine { continuation ->
+        suspendCancellableCoroutine { continuation ->
             logger.i(Tag) {
                 "Confirming authentication with token $deeplinkUri"
             }
@@ -230,7 +236,7 @@ class DefaultSupabaseAuth(
                 continuation.resume(
                     AuthApi.SessionStatus.Unauthenticated(Exception("Invalid confirmation link")),
                 )
-                return@suspendCoroutine
+                return@suspendCancellableCoroutine
             }
 
             try {

--- a/feature/diary-auth/src/commonMain/composeResources/values/strings.xml
+++ b/feature/diary-auth/src/commonMain/composeResources/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="dialog_biometric_auth_error_negative_btn_text">Exit</string>
 
     <string name="error_invalid_credentials">Invalid credentials</string>
-    <string name="error_no_credentials">No credentials</string>
+    <string name="error_no_credentials">No Google account is available on this device</string>
     <string name="error_user_already_registered">User already registered</string>
     <string name="error_generic_error">Sorry something went wrong!</string>
     <string name="registration_success_message">Thank you for registering!</string>

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModel.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.auth.AuthException
+import com.foreverrafs.auth.GenericAuthException
 import com.foreverrafs.superdiary.auth.login.screen.LoginViewState
 import com.foreverrafs.superdiary.common.utils.AppCoroutineDispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -27,7 +29,17 @@ class LoginScreenViewModel(
                 LoginViewState.Processing
             }
 
-            when (val result = authApi.signInWithGoogle()) {
+            val result = try {
+                authApi.signInWithGoogle()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                AuthApi.SessionStatus.Unauthenticated(
+                    GenericAuthException(cause = e, message = e.message),
+                )
+            }
+
+            when (result) {
                 is AuthApi.SessionStatus.Unauthenticated -> _viewState.update {
                     LoginViewState.Error(
                         error = AuthException(cause = result.exception),

--- a/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/FakeAuthApi.kt
+++ b/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/FakeAuthApi.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.flowOf
 class FakeAuthApi(
     clock: Clock = Clock.System,
 ) : AuthApi {
+    var googleSignInException: Exception? = null
+
     var signInResult: AuthApi.SessionStatus = AuthApi.SessionStatus.Authenticated(
         SessionInfo(
             expiresAt = clock.now(),
@@ -47,7 +49,7 @@ class FakeAuthApi(
     }
 
     override suspend fun signInWithGoogle(): AuthApi.SessionStatus =
-        signInResult
+        googleSignInException?.let { throw it } ?: signInResult
 
     override suspend fun signInWithGoogle(googleIdToken: String): AuthApi.SessionStatus =
         signInResult

--- a/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModelTest.kt
+++ b/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModelTest.kt
@@ -84,6 +84,18 @@ class LoginScreenViewModelTest {
     }
 
     @Test
+    fun `Should emit LoginViewState Error when signInWithGoogle throws`() = runTest {
+        authApi.googleSignInException = Exception("No credentials available")
+
+        loginViewModel.viewState.test {
+            loginViewModel.onLoginWithGoogle()
+            val state = awaitUntil { it is LoginViewState.Error }
+            expectNoEvents()
+            assertThat(state).isInstanceOf<LoginViewState.Error>()
+        }
+    }
+
+    @Test
     fun `Should emit LoginViewState Error when email login fails`() = runTest {
         authApi.signInResult = AuthApi.SessionStatus.Unauthenticated(Exception("Error logging in"))
 


### PR DESCRIPTION
## Summary
- catch Credential Manager failures across the full Android Google sign-in flow
- treat missing providers and accounts as an unauthenticated state with a clear message
- prevent provider exceptions from escaping the login ViewModel coroutine
- add regression coverage for thrown Google sign-in exceptions

## Verification
- `./gradlew :core:authentication:compileAndroidMain :feature:diary-auth:allTests`
- commit-time ktlint hook