### PR TITLE
Track feature-owned analytics events

### DIFF
--- a/androidApp/app/build.gradle.kts
+++ b/androidApp/app/build.gradle.kts
@@ -191,6 +191,7 @@ dependencies {
     implementation(libs.google.material)
     // TODO: Replace with sentry-bom from version catalog
     implementation(platform("io.sentry:sentry-bom:8.53.0"))
+    implementation(libs.sentry.android)
     implementation(projects.navigation)
     implementation(projects.sharedData)
     implementation(projects.core.diaryAi)

--- a/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/AndroidAnalytics.kt
+++ b/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/AndroidAnalytics.kt
@@ -1,10 +1,21 @@
 package com.foreverrafs.superdiary
 
-import com.foreverrafs.superdiary.core.analytics.AnalyticsEvents
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
 import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 
 class AndroidAnalytics : AnalyticsTracker {
-    override fun trackEvent(event: AnalyticsEvents) {
-        TODO("Implement Android Analytics using Firebase")
+    override fun trackEvent(event: AnalyticsEvent) {
+        val breadcrumb = Breadcrumb().apply {
+            category = "analytics"
+            message = event.name
+            level = SentryLevel.INFO
+            type = "user"
+            event.parameters.forEach(::setData)
+        }
+
+        Sentry.addBreadcrumb(breadcrumb)
     }
 }

--- a/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/MainActivity.kt
+++ b/androidApp/app/src/main/kotlin/com/foreverrafs/superdiary/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.navigation3.runtime.deeplink.DeepLinkRequest
 import androidx.navigation3.runtime.deeplink.DeepLinkUri
 import androidx.navigation3.runtime.deeplink.UriDeepLinkMatcher
@@ -24,7 +23,6 @@ class MainActivity : AppCompatActivity() {
     private val supabase: SupabaseClient by inject()
     private val logger: AggregateLogger by inject()
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val launchContext = resolveLaunchContext()

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -9,6 +9,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 dependencies {
     compileOnly(libs.conventionplugins.kover)
     compileOnly(libs.conventionplugins.ktlint)

--- a/core/analytics/src/commonMain/kotlin/com/foreverrafs/superdiary/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/com/foreverrafs/superdiary/core/analytics/AnalyticsEvent.kt
@@ -5,4 +5,7 @@ import kotlin.native.ObjCName
 
 @OptIn(ExperimentalObjCName::class)
 @ObjCName(swiftName = "AnalyticsEvent")
-interface AnalyticsEvents
+interface AnalyticsEvent {
+    val name: String
+    val parameters: Map<String, String>
+}

--- a/core/analytics/src/commonMain/kotlin/com/foreverrafs/superdiary/core/analytics/AnalyticsTracker.kt
+++ b/core/analytics/src/commonMain/kotlin/com/foreverrafs/superdiary/core/analytics/AnalyticsTracker.kt
@@ -6,5 +6,9 @@ import kotlin.native.ObjCName
 @OptIn(ExperimentalObjCName::class)
 @ObjCName(swiftName = "AnalyticsTracker")
 fun interface AnalyticsTracker {
-    fun trackEvent(event: AnalyticsEvents)
+    fun trackEvent(event: AnalyticsEvent)
+
+    companion object {
+        val NoOp: AnalyticsTracker = AnalyticsTracker { }
+    }
 }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
-
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.compose.compiler)
@@ -19,8 +17,4 @@ kotlin {
         implementation(projects.navigation)
         implementation(projects.sharedData)
     }
-}
-
-composeCompiler {
-    featureFlags.add(ComposeFeatureFlag.OptimizeNonSkippingGroups)
 }

--- a/desktopApp/src/jvmMain/kotlin/com/foreverrafs/superdiary/JvmAnalytics.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/foreverrafs/superdiary/JvmAnalytics.kt
@@ -1,10 +1,10 @@
 package com.foreverrafs.superdiary
 
-import com.foreverrafs.superdiary.core.analytics.AnalyticsEvents
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
 import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 
 class JvmAnalytics : AnalyticsTracker {
-    override fun trackEvent(event: AnalyticsEvents) {
-        TODO("Implement JVM analytics")
+    override fun trackEvent(event: AnalyticsEvent) {
+        println("Analytics event: ${event.name} ${event.parameters}")
     }
 }

--- a/feature/create-diary/build.gradle.kts
+++ b/feature/create-diary/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
             implementation(projects.core.database)
             implementation(projects.core.authentication)
             implementation(projects.core.logging)
+            implementation(projects.core.analytics)
             implementation(projects.core.permission)
         }
 

--- a/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/analytics/CreateDiaryAnalyticsEvent.kt
+++ b/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/analytics/CreateDiaryAnalyticsEvent.kt
@@ -1,0 +1,23 @@
+package com.foreverrafs.superdiary.creatediary.analytics
+
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+
+internal sealed interface CreateDiaryAnalyticsEvent : AnalyticsEvent {
+    data class DiaryCreated(
+        val hasLocation: Boolean,
+    ) : CreateDiaryAnalyticsEvent {
+        override val name: String = "diary_created"
+        override val parameters: Map<String, String> = mapOf(
+            "has_location" to hasLocation.toString(),
+        )
+    }
+
+    data class AIDiaryRequested(
+        val wordCount: Int,
+    ) : CreateDiaryAnalyticsEvent {
+        override val name: String = "ai_diary_requested"
+        override val parameters: Map<String, String> = mapOf(
+            "word_count" to wordCount.toString(),
+        )
+    }
+}

--- a/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/screen/CreateDiaryViewModel.kt
+++ b/feature/create-diary/src/commonMain/kotlin/com/foreverrafs/superdiary/creatediary/screen/CreateDiaryViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.viewModelScope
 import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.preferences.DiaryPreference
 import com.foreverrafs.superdiary.ai.api.DiaryAI
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import com.foreverrafs.superdiary.core.location.Location
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import com.foreverrafs.superdiary.core.permission.LocationManager
 import com.foreverrafs.superdiary.core.permission.LocationPermissionManager
 import com.foreverrafs.superdiary.core.permission.PermissionState
 import com.foreverrafs.superdiary.core.permission.PermissionsControllerWrapper
+import com.foreverrafs.superdiary.creatediary.analytics.CreateDiaryAnalyticsEvent
 import com.foreverrafs.superdiary.creatediary.usecase.AddDiaryUseCase
 import com.foreverrafs.superdiary.data.Result
 import com.foreverrafs.superdiary.domain.model.Diary
@@ -33,6 +35,7 @@ class CreateDiaryViewModel(
     private val locationPermissionManager: LocationPermissionManager,
     private val preference: DiaryPreference,
     authApi: AuthApi,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
 
     val permissionState: StateFlow<PermissionState> = locationPermissionManager
@@ -107,6 +110,11 @@ class CreateDiaryViewModel(
             }
 
             is Result.Success -> {
+                analyticsTracker.trackEvent(
+                    CreateDiaryAnalyticsEvent.DiaryCreated(
+                        hasLocation = diary.location != Location.Empty,
+                    ),
+                )
                 logger.i(Tag) {
                     "Diary entry successfully saved: $diary"
                 }
@@ -114,8 +122,10 @@ class CreateDiaryViewModel(
         }
     }
 
-    fun generateAIDiary(prompt: String, wordCount: Int): Flow<String> =
-        diaryAI.generateDiary(prompt, wordCount)
+    fun generateAIDiary(prompt: String, wordCount: Int): Flow<String> {
+        analyticsTracker.trackEvent(CreateDiaryAnalyticsEvent.AIDiaryRequested(wordCount))
+        return diaryAI.generateDiary(prompt, wordCount)
+    }
 
     fun onRequestLocationPermission() = viewModelScope.launch {
         locationPermissionManager.provideLocationPermission()

--- a/feature/create-diary/src/commonTest/kotlin/com/foreverrafs/superdiary/creatediary/CreateDiaryViewModelTest.kt
+++ b/feature/create-diary/src/commonTest/kotlin/com/foreverrafs/superdiary/creatediary/CreateDiaryViewModelTest.kt
@@ -2,6 +2,7 @@ package com.foreverrafs.superdiary.creatediary
 
 import app.cash.turbine.test
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -9,11 +10,14 @@ import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.preferences.DiaryPreference
 import com.foreverrafs.superdiary.ai.api.DiaryAI
 import com.foreverrafs.superdiary.common.coroutines.TestAppDispatchers
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import com.foreverrafs.superdiary.core.permission.LocationManager
 import com.foreverrafs.superdiary.core.permission.LocationPermissionManager
 import com.foreverrafs.superdiary.core.permission.PermissionState
 import com.foreverrafs.superdiary.creatediary.FakePermissionsControllerWrapper.ActionPerformed
+import com.foreverrafs.superdiary.creatediary.analytics.CreateDiaryAnalyticsEvent
 import com.foreverrafs.superdiary.creatediary.screen.CreateDiaryViewModel
 import com.foreverrafs.superdiary.creatediary.usecase.AddDiaryUseCase
 import com.foreverrafs.superdiary.domain.model.Diary
@@ -68,6 +72,7 @@ class CreateDiaryViewModelTest {
     private val preference: DiaryPreference = mock()
 
     private lateinit var createDiaryViewModel: CreateDiaryViewModel
+    private val trackedEvents = mutableListOf<AnalyticsEvent>()
 
     private val permissionsController: FakePermissionsControllerWrapper =
         FakePermissionsControllerWrapper()
@@ -75,6 +80,7 @@ class CreateDiaryViewModelTest {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(TestAppDispatchers.main)
+        trackedEvents.clear()
 
         every { preference.settings }.returns(emptyFlow())
         everySuspend { preference.getSnapshot() }.returns(DiarySettings.Empty)
@@ -96,6 +102,7 @@ class CreateDiaryViewModelTest {
             ),
             preference = preference,
             authApi = authApi,
+            analyticsTracker = AnalyticsTracker(trackedEvents::add),
         )
     }
 
@@ -127,6 +134,9 @@ class CreateDiaryViewModelTest {
         delay(100)
 
         verifySuspend { dataSource.save(diary) }
+        assertThat(trackedEvents).isEqualTo(
+            listOf(CreateDiaryAnalyticsEvent.DiaryCreated(hasLocation = false)),
+        )
     }
 
     @Test

--- a/feature/create-diary/src/commonTest/kotlin/com/foreverrafs/superdiary/creatediary/analytics/CreateDiaryAnalyticsEventTest.kt
+++ b/feature/create-diary/src/commonTest/kotlin/com/foreverrafs/superdiary/creatediary/analytics/CreateDiaryAnalyticsEventTest.kt
@@ -1,0 +1,22 @@
+package com.foreverrafs.superdiary.creatediary.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CreateDiaryAnalyticsEventTest {
+    @Test
+    fun `diary created includes location state`() {
+        val event = CreateDiaryAnalyticsEvent.DiaryCreated(hasLocation = true)
+
+        assertEquals("diary_created", event.name)
+        assertEquals(mapOf("has_location" to "true"), event.parameters)
+    }
+
+    @Test
+    fun `AI diary requested includes word count`() {
+        val event = CreateDiaryAnalyticsEvent.AIDiaryRequested(wordCount = 250)
+
+        assertEquals("ai_diary_requested", event.name)
+        assertEquals(mapOf("word_count" to "250"), event.parameters)
+    }
+}

--- a/feature/diary-auth/build.gradle.kts
+++ b/feature/diary-auth/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             implementation(libs.jetbrains.compose.resources)
             implementation(libs.jetbrains.compose.preview)
             implementation(projects.core.logging)
+            implementation(projects.core.analytics)
             implementation(libs.androidx.core.uri)
             implementation(libs.jetbrains.compose.navigation3)
             implementation(libs.kotlinx.serialization.json)

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/analytics/AuthAnalyticsEvent.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/analytics/AuthAnalyticsEvent.kt
@@ -1,0 +1,19 @@
+package com.foreverrafs.superdiary.auth.analytics
+
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+
+internal sealed interface AuthAnalyticsEvent : AnalyticsEvent {
+    data class Login(
+        val method: String,
+    ) : AuthAnalyticsEvent {
+        override val name: String = "login"
+        override val parameters: Map<String, String> = mapOf("method" to method)
+    }
+
+    data class Registration(
+        val method: String,
+    ) : AuthAnalyticsEvent {
+        override val name: String = "sign_up"
+        override val parameters: Map<String, String> = mapOf("method" to method)
+    }
+}

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModel.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModel.kt
@@ -6,8 +6,10 @@ import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.auth.AuthException
 import com.foreverrafs.auth.AuthUiContext
 import com.foreverrafs.auth.GenericAuthException
+import com.foreverrafs.superdiary.auth.analytics.AuthAnalyticsEvent
 import com.foreverrafs.superdiary.auth.login.screen.LoginViewState
 import com.foreverrafs.superdiary.common.utils.AppCoroutineDispatchers
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,6 +19,7 @@ import kotlinx.coroutines.launch
 class LoginScreenViewModel(
     private val authApi: AuthApi,
     private val coroutineDispatchers: AppCoroutineDispatchers,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
     private val _viewState: MutableStateFlow<LoginViewState> =
         MutableStateFlow(LoginViewState.Idle)
@@ -47,10 +50,13 @@ class LoginScreenViewModel(
                     )
                 }
 
-                is AuthApi.SessionStatus.Authenticated -> _viewState.update { currentState ->
-                    result.sessionInfo.userInfo?.let {
-                        LoginViewState.Success(it)
-                    } ?: currentState
+                is AuthApi.SessionStatus.Authenticated -> {
+                    analyticsTracker.trackEvent(AuthAnalyticsEvent.Login(method = "google"))
+                    _viewState.update { currentState ->
+                        result.sessionInfo.userInfo?.let {
+                            LoginViewState.Success(it)
+                        } ?: currentState
+                    }
                 }
             }
         }
@@ -68,10 +74,13 @@ class LoginScreenViewModel(
                     )
                 }
 
-                is AuthApi.SessionStatus.Authenticated -> _viewState.update { currentState ->
-                    result.sessionInfo.userInfo?.let {
-                        LoginViewState.Success(it)
-                    } ?: currentState
+                is AuthApi.SessionStatus.Authenticated -> {
+                    analyticsTracker.trackEvent(AuthAnalyticsEvent.Login(method = "email"))
+                    _viewState.update { currentState ->
+                        result.sessionInfo.userInfo?.let {
+                            LoginViewState.Success(it)
+                        } ?: currentState
+                    }
                 }
             }
         }

--- a/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/RegisterScreenViewModel.kt
+++ b/feature/diary-auth/src/commonMain/kotlin/com/foreverrafs/superdiary/auth/register/RegisterScreenViewModel.kt
@@ -3,8 +3,10 @@ package com.foreverrafs.superdiary.auth.register
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foreverrafs.auth.AuthApi
+import com.foreverrafs.superdiary.auth.analytics.AuthAnalyticsEvent
 import com.foreverrafs.superdiary.auth.register.screen.RegisterScreenState
 import com.foreverrafs.superdiary.common.utils.AppCoroutineDispatchers
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -14,6 +16,7 @@ class RegisterScreenViewModel(
     private val authApi: AuthApi,
     private val coroutineDispatchers: AppCoroutineDispatchers,
     private val formValidator: RegistrationFormValidator,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
     private val _viewState: MutableStateFlow<RegisterScreenState> =
         MutableStateFlow(RegisterScreenState.Idle)
@@ -72,8 +75,11 @@ class RegisterScreenViewModel(
                 )
             }
 
-            is AuthApi.RegistrationStatus.Success -> _viewState.update {
-                RegisterScreenState.Success
+            is AuthApi.RegistrationStatus.Success -> {
+                analyticsTracker.trackEvent(AuthAnalyticsEvent.Registration(method = "email"))
+                _viewState.update {
+                    RegisterScreenState.Success
+                }
             }
         }
     }

--- a/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/analytics/AuthAnalyticsEventTest.kt
+++ b/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/analytics/AuthAnalyticsEventTest.kt
@@ -1,0 +1,22 @@
+package com.foreverrafs.superdiary.auth.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthAnalyticsEventTest {
+    @Test
+    fun `login includes authentication method`() {
+        val event = AuthAnalyticsEvent.Login(method = "google")
+
+        assertEquals("login", event.name)
+        assertEquals(mapOf("method" to "google"), event.parameters)
+    }
+
+    @Test
+    fun `registration includes authentication method`() {
+        val event = AuthAnalyticsEvent.Registration(method = "email")
+
+        assertEquals("sign_up", event.name)
+        assertEquals(mapOf("method" to "email"), event.parameters)
+    }
+}

--- a/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModelTest.kt
+++ b/feature/diary-auth/src/commonTest/kotlin/com/foreverrafs/superdiary/auth/login/LoginScreenViewModelTest.kt
@@ -2,19 +2,22 @@ package com.foreverrafs.superdiary.auth.login
 
 import app.cash.turbine.test
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.auth.AuthUiContext
 import com.foreverrafs.auth.model.SessionInfo
 import com.foreverrafs.auth.model.UserInfo
+import com.foreverrafs.superdiary.auth.analytics.AuthAnalyticsEvent
 import com.foreverrafs.superdiary.auth.login.screen.LoginViewState
 import com.foreverrafs.superdiary.common.coroutines.TestAppDispatchers
 import com.foreverrafs.superdiary.common.coroutines.awaitUntil
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
@@ -25,17 +28,19 @@ import kotlinx.coroutines.test.setMain
 class LoginScreenViewModelTest {
     private val authUiContext = object : AuthUiContext {}
     private lateinit var loginViewModel: LoginScreenViewModel
+    private val trackedEvents = mutableListOf<AnalyticsEvent>()
 
-    @OptIn(ExperimentalTime::class)
     private val authApi: FakeAuthApi = FakeAuthApi()
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(TestAppDispatchers.main)
+        trackedEvents.clear()
 
         loginViewModel = LoginScreenViewModel(
             authApi = authApi,
             coroutineDispatchers = TestAppDispatchers,
+            analyticsTracker = AnalyticsTracker(trackedEvents::add),
         )
     }
 
@@ -109,7 +114,6 @@ class LoginScreenViewModelTest {
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     @Test
     fun `Should emit LoginViewState Success when signInWithGoogle succeeds`() = runTest {
         authApi.signInResult = AuthApi.SessionStatus.Authenticated(
@@ -132,5 +136,9 @@ class LoginScreenViewModelTest {
             expectNoEvents()
             assertThat(state).isInstanceOf<LoginViewState.Success>()
         }
+
+        assertThat(trackedEvents).isEqualTo(
+            listOf(AuthAnalyticsEvent.Login(method = "google")),
+        )
     }
 }

--- a/feature/diary-list/build.gradle.kts
+++ b/feature/diary-list/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             implementation(libs.jetbrains.compose.resources)
             implementation(libs.jetbrains.compose.preview)
             implementation(projects.core.logging)
+            implementation(projects.core.analytics)
             implementation(projects.core.uiComponents)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.koin.compose)

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/analytics/DiaryListAnalyticsEvent.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/analytics/DiaryListAnalyticsEvent.kt
@@ -1,0 +1,21 @@
+package com.foreverrafs.superdiary.list.analytics
+
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+
+internal sealed interface DiaryListAnalyticsEvent : AnalyticsEvent {
+    data class DiaryDeleted(
+        val count: Int,
+    ) : DiaryListAnalyticsEvent {
+        override val name: String = "diary_deleted"
+        override val parameters: Map<String, String> = mapOf("count" to count.toString())
+    }
+
+    data class FavoriteChanged(
+        val isFavorite: Boolean,
+    ) : DiaryListAnalyticsEvent {
+        override val name: String = "favorite_changed"
+        override val parameters: Map<String, String> = mapOf(
+            "is_favorite" to isFavorite.toString(),
+        )
+    }
+}

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/DetailsViewModel.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/detail/DetailsViewModel.kt
@@ -3,10 +3,12 @@ package com.foreverrafs.superdiary.list.presentation.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foreverrafs.auth.AuthApi
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import com.foreverrafs.superdiary.data.Result
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.domain.usecase.GetDiaryByIdUseCase
+import com.foreverrafs.superdiary.list.analytics.DiaryListAnalyticsEvent
 import com.foreverrafs.superdiary.list.domain.usecase.DeleteDiaryUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,6 +33,7 @@ class DetailsViewModel(
     private val getDiaryByIdUseCase: GetDiaryByIdUseCase,
     private val logger: AggregateLogger,
     private val authApi: AuthApi,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
 
     private val _deleteDiaryState = MutableStateFlow<DeleteDiaryState?>(null)
@@ -51,6 +54,9 @@ class DetailsViewModel(
                 val deletedItems = result.data
 
                 if (deletedItems != 0) {
+                    analyticsTracker.trackEvent(
+                        DiaryListAnalyticsEvent.DiaryDeleted(deletedItems),
+                    )
                     _deleteDiaryState.update {
                         DeleteDiaryState.Success(deletedItems)
                     }

--- a/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/list/DiaryListViewModel.kt
+++ b/feature/diary-list/src/commonMain/kotlin/com/foreverrafs/superdiary/list/presentation/list/DiaryListViewModel.kt
@@ -6,12 +6,14 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.components.diarylist.DiaryFilters
 import com.foreverrafs.auth.AuthApi
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import com.foreverrafs.superdiary.data.Result
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.domain.usecase.SearchDiaryByDateUseCase
 import com.foreverrafs.superdiary.domain.usecase.SearchDiaryByEntryUseCase
 import com.foreverrafs.superdiary.domain.usecase.UpdateDiaryUseCase
+import com.foreverrafs.superdiary.list.analytics.DiaryListAnalyticsEvent
 import com.foreverrafs.superdiary.list.domain.usecase.DeleteDiaryUseCase
 import com.foreverrafs.superdiary.list.domain.usecase.GetAllDiariesUseCase
 import com.foreverrafs.superdiary.utils.toInstant
@@ -45,6 +47,7 @@ internal class DiaryListViewModel(
     private val updateDiaryUseCase: UpdateDiaryUseCase,
     private val logger: AggregateLogger,
     private val authApi: AuthApi,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
 
     private val filters: MutableStateFlow<DiaryFilters> = MutableStateFlow(DiaryFilters())
@@ -117,7 +120,13 @@ internal class DiaryListViewModel(
 
     suspend fun deleteDiaries(diaries: List<Diary>): Boolean =
         when (val result = deleteDiaryUseCase(diaries)) {
-            is Result.Success -> result.data == diaries.size
+            is Result.Success -> (result.data == diaries.size).also { allDeleted ->
+                if (allDeleted) {
+                    analyticsTracker.trackEvent(
+                        DiaryListAnalyticsEvent.DiaryDeleted(result.data),
+                    )
+                }
+            }
             is Result.Failure -> false
         }
 
@@ -140,7 +149,15 @@ internal class DiaryListViewModel(
                 logger.d(Tag) {
                     "Favorite toggled"
                 }
-                result.data
+                result.data.also { updated ->
+                    if (updated) {
+                        analyticsTracker.trackEvent(
+                            DiaryListAnalyticsEvent.FavoriteChanged(
+                                isFavorite = !diary.isFavorite,
+                            ),
+                        )
+                    }
+                }
             }
         }
     }

--- a/feature/diary-list/src/commonTest/kotlin/com/foreverrafs/superdiary/list/analytics/DiaryListAnalyticsEventTest.kt
+++ b/feature/diary-list/src/commonTest/kotlin/com/foreverrafs/superdiary/list/analytics/DiaryListAnalyticsEventTest.kt
@@ -1,0 +1,22 @@
+package com.foreverrafs.superdiary.list.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DiaryListAnalyticsEventTest {
+    @Test
+    fun `diary deleted includes deleted count`() {
+        val event = DiaryListAnalyticsEvent.DiaryDeleted(count = 3)
+
+        assertEquals("diary_deleted", event.name)
+        assertEquals(mapOf("count" to "3"), event.parameters)
+    }
+
+    @Test
+    fun `favorite changed includes current favorite state`() {
+        val event = DiaryListAnalyticsEvent.FavoriteChanged(isFavorite = true)
+
+        assertEquals("favorite_changed", event.name)
+        assertEquals(mapOf("is_favorite" to "true"), event.parameters)
+    }
+}

--- a/feature/diary-list/src/commonTest/kotlin/com/foreverrafs/superdiary/list/presentation/DiaryListViewModelTest.kt
+++ b/feature/diary-list/src/commonTest/kotlin/com/foreverrafs/superdiary/list/presentation/DiaryListViewModelTest.kt
@@ -3,18 +3,22 @@ package com.foreverrafs.superdiary.list.presentation
 import androidx.paging.PagingData
 import app.cash.turbine.test
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.components.diarylist.DiaryFilters
 import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.auth.model.UserInfo
 import com.foreverrafs.superdiary.common.coroutines.TestAppDispatchers
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
 import com.foreverrafs.superdiary.core.logging.AggregateLogger
 import com.foreverrafs.superdiary.domain.model.Diary
 import com.foreverrafs.superdiary.domain.repository.DataSource
 import com.foreverrafs.superdiary.domain.usecase.SearchDiaryByDateUseCase
 import com.foreverrafs.superdiary.domain.usecase.SearchDiaryByEntryUseCase
 import com.foreverrafs.superdiary.domain.usecase.UpdateDiaryUseCase
+import com.foreverrafs.superdiary.list.analytics.DiaryListAnalyticsEvent
 import com.foreverrafs.superdiary.list.domain.repository.DiaryListRepository
 import com.foreverrafs.superdiary.list.domain.usecase.DeleteDiaryUseCase
 import com.foreverrafs.superdiary.list.domain.usecase.GetAllDiariesUseCase
@@ -46,6 +50,7 @@ import kotlinx.coroutines.test.setMain
 class DiaryListViewModelTest {
 
     private val dataSource: DataSource = mock()
+    private val trackedEvents = mutableListOf<AnalyticsEvent>()
 
     private lateinit var diaryListViewModel: DiaryListViewModel
 
@@ -75,6 +80,7 @@ class DiaryListViewModelTest {
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(StandardTestDispatcher())
+        trackedEvents.clear()
 
         every { dataSource.findByDatePaged(any()) }.returns(
             flowOf(PagingData.from(listOf(diary))),
@@ -103,6 +109,7 @@ class DiaryListViewModelTest {
             deleteDiaryUseCase = DeleteDiaryUseCase(dataSource, TestAppDispatchers),
             logger = AggregateLogger(emptyList()),
             authApi = authApi,
+            analyticsTracker = AnalyticsTracker(trackedEvents::add),
         )
     }
 
@@ -192,9 +199,13 @@ class DiaryListViewModelTest {
             dataSource.delete(diaries = any())
         }.returns(1)
 
-        diaryListViewModel.deleteDiaries(diaries = listOf())
+        val result = diaryListViewModel.deleteDiaries(diaries = listOf(diary))
 
         verifySuspend { dataSource.delete(diaries = any()) }
+        assertThat(result).isTrue()
+        assertThat(trackedEvents).isEqualTo(
+            listOf(DiaryListAnalyticsEvent.DiaryDeleted(count = 1)),
+        )
     }
 
     @Test
@@ -207,6 +218,7 @@ class DiaryListViewModelTest {
 
         verifySuspend { dataSource.delete(diaries = any()) }
         assertThat(result).isFalse()
+        assertThat(trackedEvents).isEqualTo(emptyList())
     }
 
     @Test
@@ -219,6 +231,9 @@ class DiaryListViewModelTest {
 
         verifySuspend { dataSource.update(any()) }
         assertThat(result).isTrue()
+        assertThat(trackedEvents).isEqualTo(
+            listOf(DiaryListAnalyticsEvent.FavoriteChanged(isFavorite = true)),
+        )
     }
 
     @Test
@@ -231,5 +246,6 @@ class DiaryListViewModelTest {
 
         verifySuspend { dataSource.update(any()) }
         assertThat(result).isFalse()
+        assertThat(trackedEvents).isEqualTo(emptyList())
     }
 }

--- a/feature/diary-profile/build.gradle.kts
+++ b/feature/diary-profile/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
             implementation(libs.jetbrains.compose.preview)
             implementation(libs.jetbrains.compose.navigation3)
             implementation(projects.core.logging)
+            implementation(projects.core.analytics)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)

--- a/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/analytics/Logout.kt
+++ b/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/analytics/Logout.kt
@@ -1,0 +1,8 @@
+package com.foreverrafs.superdiary.profile.analytics
+
+import com.foreverrafs.superdiary.core.analytics.AnalyticsEvent
+
+internal data object Logout : AnalyticsEvent {
+    override val name: String = "logout"
+    override val parameters: Map<String, String> = emptyMap()
+}

--- a/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/presentation/ProfileScreenViewModel.kt
+++ b/feature/diary-profile/src/commonMain/kotlin/com/foreverrafs/superdiary/profile/presentation/ProfileScreenViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.foreverrafs.auth.AuthApi
 import com.foreverrafs.preferences.DiaryPreference
+import com.foreverrafs.superdiary.core.analytics.AnalyticsTracker
+import com.foreverrafs.superdiary.profile.analytics.Logout
 import com.foreverrafs.superdiary.profile.domain.usecase.SignOutUseCase
 import com.foreverrafs.superdiary.utils.DiarySettings
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +29,7 @@ class ProfileScreenViewModel(
     private val authApi: AuthApi,
     private val preference: DiaryPreference,
     private val signOutUseCase: SignOutUseCase,
+    private val analyticsTracker: AnalyticsTracker = AnalyticsTracker.NoOp,
 ) : ViewModel() {
     private val _viewState: MutableStateFlow<ProfileScreenViewData> = MutableStateFlow(
         ProfileScreenViewData(),
@@ -64,6 +67,7 @@ class ProfileScreenViewModel(
 
         _viewState.update {
             if (result.isSuccess) {
+                analyticsTracker.trackEvent(Logout)
                 it.copy(isLogoutSuccess = true)
             } else {
                 it.copy(

--- a/feature/diary-profile/src/commonTest/kotlin/com/foreverrafs/superdiary/profile/analytics/LogoutAnalyticsEventTest.kt
+++ b/feature/diary-profile/src/commonTest/kotlin/com/foreverrafs/superdiary/profile/analytics/LogoutAnalyticsEventTest.kt
@@ -1,0 +1,13 @@
+package com.foreverrafs.superdiary.profile.analytics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LogoutAnalyticsEventTest {
+    @Test
+    fun `logout has no parameters`() {
+        assertEquals("logout", Logout.name)
+        assertTrue(Logout.parameters.isEmpty())
+    }
+}

--- a/iosApp/iosApp/analytics/AppleAnalytics.swift
+++ b/iosApp/iosApp/analytics/AppleAnalytics.swift
@@ -1,9 +1,13 @@
 import Foundation
 import shared
+import Sentry
 
 class AppleAnalytics: AnalyticsTracker {
     func trackEvent(event: AnalyticsEvent) {
-        
-        // Implement this soon
+        let breadcrumb = Breadcrumb(level: .info, category: "analytics")
+        breadcrumb.type = "user"
+        breadcrumb.message = event.name
+        breadcrumb.data = ["parameters": event.parameters.description]
+        SentrySDK.addBreadcrumb(breadcrumb)
     }
 }


### PR DESCRIPTION
## Summary

- keep only the analytics event contract and tracker in the core analytics module
- define event catalogs within auth, diary creation, diary list, and profile features
- track successful authentication, diary creation/deletion, favorite changes, AI diary requests, and logout across Android, iOS, and desktop
- report Android and iOS events as Sentry breadcrumbs
- add event schema tests and verify success-only tracking behavior

## Testing

- ./gradlew :feature:create-diary:jvmTest :feature:diary-auth:jvmTest :feature:diary-list:jvmTest :feature:diary-profile:jvmTest
- ./gradlew :core:analytics:ktlintCheck :feature:create-diary:ktlintCheck :feature:diary-auth:ktlintCheck :feature:diary-list:ktlintCheck :feature:diary-profile:ktlintCheck :androidApp:app:ktlintCheck :desktopApp:ktlintCheck
- ./gradlew :core:analytics:compileKotlinJvm :feature:create-diary:compileKotlinJvm :feature:diary-auth:compileKotlinJvm :feature:diary-list:compileKotlinJvm :feature:diary-profile:compileKotlinJvm :androidApp:app:compileStandardDebugKotlin :umbrella:linkDebugFrameworkIosSimulatorArm64