### PR TITLE
feat: use native iOS bottom navigation

### DIFF
--- a/navigation/src/androidMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.android.kt
+++ b/navigation/src/androidMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.android.kt
@@ -1,0 +1,61 @@
+package com.foreverrafs.superdiary.ui.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.navigation3.runtime.NavKey
+import com.foreverrafs.superdiary.design.components.LabelSmallText
+import com.foreverrafs.superdiary.ui.navigation.SuperDiaryTab
+
+@Composable
+actual fun SuperDiaryBottomBar(
+    items: List<SuperDiaryTab>,
+    selected: NavKey,
+    onItemClick: (SuperDiaryTab) -> Unit,
+    modifier: Modifier,
+) {
+    NavigationBar(modifier) {
+        items.forEach { tab ->
+            BottomNavigationItem(
+                tab = tab,
+                selected = selected == tab,
+            ) {
+                onItemClick(tab)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.BottomNavigationItem(
+    tab: SuperDiaryTab,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    NavigationBarItem(
+        modifier = Modifier.testTag(tab.title),
+        selected = selected,
+        onClick = onClick,
+        icon = {
+            Icon(
+                painter = if (selected) {
+                    tab.selectedIcon.painter()
+                } else {
+                    tab.icon.painter()
+                },
+                contentDescription = tab.title,
+            )
+        },
+        label = {
+            LabelSmallText(
+                text = tab.title,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+            )
+        },
+    )
+}

--- a/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.kt
+++ b/navigation/src/commonMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.kt
@@ -1,62 +1,14 @@
 package com.foreverrafs.superdiary.ui.components
 
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation3.runtime.NavKey
-import com.foreverrafs.superdiary.design.components.LabelSmallText
 import com.foreverrafs.superdiary.ui.navigation.SuperDiaryTab
 
 @Composable
-fun SuperDiaryBottomBar(
+expect fun SuperDiaryBottomBar(
     items: List<SuperDiaryTab>,
     selected: NavKey,
     onItemClick: (SuperDiaryTab) -> Unit,
     modifier: Modifier = Modifier,
-) {
-    NavigationBar(modifier) {
-        items.forEach { tab ->
-            BottomNavigationItem(
-                tab = tab,
-                selected = selected == tab,
-            ) {
-                onItemClick(tab)
-            }
-        }
-    }
-}
-
-@Composable
-private fun RowScope.BottomNavigationItem(
-    tab: SuperDiaryTab,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    NavigationBarItem(
-        modifier = Modifier.testTag(tab.title),
-        selected = selected,
-        onClick = onClick,
-        icon = {
-            Icon(
-                painter = if (selected) {
-                    tab.selectedIcon.painter()
-                } else {
-                    tab.icon.painter()
-                },
-                contentDescription = tab.title,
-            )
-        },
-        label = {
-            LabelSmallText(
-                text = tab.title,
-                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-            )
-        },
-    )
-}
+)

--- a/navigation/src/iosMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.ios.kt
+++ b/navigation/src/iosMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.ios.kt
@@ -1,0 +1,101 @@
+package com.foreverrafs.superdiary.ui.components
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.UIKitView
+import androidx.navigation3.runtime.NavKey
+import com.foreverrafs.superdiary.ui.navigation.SuperDiaryTab
+import com.foreverrafs.superdiary.ui.navigation.TopLevelRoute
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIImage
+import platform.UIKit.UITabBar
+import platform.UIKit.UITabBarDelegateProtocol
+import platform.UIKit.UITabBarItem
+
+private const val BOTTOM_BAR_TEST_TAG = "native-ios-liquid-glass-bottom-bar"
+
+@Composable
+actual fun SuperDiaryBottomBar(
+    items: List<SuperDiaryTab>,
+    selected: NavKey,
+    onItemClick: (SuperDiaryTab) -> Unit,
+    modifier: Modifier,
+) {
+    UIKitView(
+        factory = { LiquidGlassTabBar() },
+        modifier = modifier
+            .height(84.dp)
+            .testTag(BOTTOM_BAR_TEST_TAG),
+        update = { tabBar ->
+            tabBar.update(
+                items = items,
+                selected = selected,
+                onItemClick = onItemClick,
+            )
+        },
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private class LiquidGlassTabBar : UITabBar(frame = CGRectMake(0.0, 0.0, 0.0, 0.0)), UITabBarDelegateProtocol {
+    private var currentItems: List<SuperDiaryTab> = emptyList()
+    private var onItemClick: (SuperDiaryTab) -> Unit = {}
+
+    init {
+        delegate = this
+    }
+
+    fun update(
+        items: List<SuperDiaryTab>,
+        selected: NavKey,
+        onItemClick: (SuperDiaryTab) -> Unit,
+    ) {
+        this.currentItems = items
+        this.onItemClick = onItemClick
+
+        val existingItems = this.items.orEmpty()
+        if (existingItems.size != items.size || existingItems.zip(items).any { (tabBarItem, tab) ->
+                (tabBarItem as UITabBarItem).title != tab.title
+            }
+        ) {
+            this.items = items.mapIndexed { index, tab ->
+                UITabBarItem(
+                    title = tab.title,
+                    image = UIImage.systemImageNamed(tab.systemImageName),
+                    tag = index.toLong(),
+                ).apply {
+                    selectedImage = UIImage.systemImageNamed(tab.selectedSystemImageName)
+                }
+            }
+        }
+
+        selectedItem = this.items
+            ?.getOrNull(items.indexOfFirst { it == selected }) as? UITabBarItem
+    }
+
+    override fun tabBar(tabBar: UITabBar, didSelectItem: UITabBarItem) {
+        currentItems.getOrNull(didSelectItem.tag.toInt())?.let(onItemClick)
+    }
+}
+
+private val SuperDiaryTab.systemImageName: String
+    get() = when (this) {
+        TopLevelRoute.DashboardTab -> "chart.bar"
+        TopLevelRoute.DiaryList -> "list.bullet"
+        TopLevelRoute.FavoriteTab -> "heart"
+        TopLevelRoute.WritingInsightsTab -> "lightbulb"
+        else -> "circle"
+    }
+
+private val SuperDiaryTab.selectedSystemImageName: String
+    get() = when (this) {
+        TopLevelRoute.DashboardTab -> "chart.bar.fill"
+        TopLevelRoute.DiaryList -> "list.bullet"
+        TopLevelRoute.FavoriteTab -> "heart.fill"
+        TopLevelRoute.WritingInsightsTab -> "lightbulb.fill"
+        else -> "circle.fill"
+    }

--- a/navigation/src/jvmMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.jvm.kt
+++ b/navigation/src/jvmMain/kotlin/com/foreverrafs/superdiary/ui/components/SuperDiaryBottomBar.jvm.kt
@@ -1,0 +1,61 @@
+package com.foreverrafs.superdiary.ui.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.navigation3.runtime.NavKey
+import com.foreverrafs.superdiary.design.components.LabelSmallText
+import com.foreverrafs.superdiary.ui.navigation.SuperDiaryTab
+
+@Composable
+actual fun SuperDiaryBottomBar(
+    items: List<SuperDiaryTab>,
+    selected: NavKey,
+    onItemClick: (SuperDiaryTab) -> Unit,
+    modifier: Modifier,
+) {
+    NavigationBar(modifier) {
+        items.forEach { tab ->
+            BottomNavigationItem(
+                tab = tab,
+                selected = selected == tab,
+            ) {
+                onItemClick(tab)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.BottomNavigationItem(
+    tab: SuperDiaryTab,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    NavigationBarItem(
+        modifier = Modifier.testTag(tab.title),
+        selected = selected,
+        onClick = onClick,
+        icon = {
+            Icon(
+                painter = if (selected) {
+                    tab.selectedIcon.painter()
+                } else {
+                    tab.icon.painter()
+                },
+                contentDescription = tab.title,
+            )
+        },
+        label = {
+            LabelSmallText(
+                text = tab.title,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+            )
+        },
+    )
+}


### PR DESCRIPTION
## Summary
- Move SuperDiaryBottomBar behind a Kotlin Multiplatform expect/actual API
- Keep the existing Compose Material3 bottom navigation for Android and JVM
- Render iOS bottom navigation through a native UIKit UITabBar so iOS can use the system Liquid Glass tab bar behavior/appearance
- Map SuperDiary top-level tabs to SF Symbols for native iOS tab items

## Test Plan
- ./gradlew :navigation:compileKotlinIosSimulatorArm64 --no-daemon --no-configuration-cache --max-workers=1 -Dorg.gradle.jvmargs='-Xmx3g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8'
- ./gradlew :navigation:compileKotlinIosSimulatorArm64 :navigation:compileAndroidMain :navigation:compileKotlinJvm :navigation:ktlintCheck --no-daemon --no-configuration-cache --max-workers=1 -Dorg.gradle.jvmargs='-Xmx3g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8'
- git diff --check